### PR TITLE
Perf optimization work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,13 @@ else()
       set(NAT "")
     endif()
 
+    # TODO(cao) - fix this build option
+    # enable LTO on build option
+    if(LTO STREQUAL "1")
+      set(LTO "-flto")
+    else()
+      set(LTO "")
+    endif()
 
     # by default - do not stripe symbols in release, only when specified to reduce binary size
     if(SYM STREQUAL "1")
@@ -131,7 +138,7 @@ else()
     # On my daily dev machine, it gives me this value: skylake-avx512
     # In another machine, I found it as "haswell", and this may lead crash with `illegal instruction` failure.
     # So to make sure the published image works more broadly, we may want to remove this `-march=native`, or specify the target value
-    set(NCFLAGS_RELEASE "-Ofast ${NAT} ${SYM}")
+    set(NCFLAGS_RELEASE "-Ofast ${NAT} ${SYM} ${LTO}")
   endif()
 endif()
 

--- a/bench/readme.md
+++ b/bench/readme.md
@@ -1,0 +1,49 @@
+benchmark nebula
+
+People has been asking the benchmark comparing to other engine such as druid.
+This note is trying to reproduce the similar benchmark druid did before and show some initial results.
+
+# Benchmark Data & Query
+The data is standard 100GB TPC-H benchmark source.
+- data: https://gist.githubusercontent.com/xvrl/9552286/raw/77a134359ba73eaffcb30de0792ed3f19c209535/download-data.sh
+- schema: https://github.com/druid-io/druid-benchmark/blob/master/lineitem.task.json#L14-L29
+
+Druid benchmark result: https://druid.apache.org/blog/2014/03/17/benchmarking-druid.html (a bit old)
+
+## Prepare data
+Download the data and use this spec to load it into Nebula test cluster with 3 EC2 c5.4x machines (16 cores).
+- download: `for i in $(seq 1 100) ; do curl -O http://static.druid.io/data/benchmarks/tpch/100/lineitem.tbl.$i.gz ; done`
+- decompress: `for i in $(seq 1 100) ; do gzip -d lineitem.tbl.$i.gz; done`
+- (optional) upload to s3: `for i in $(seq 1 100) ; do s3 cp lineitem.tbl.$i s3://nebula/bench/lineitem.tbl.$i; done`
+
+## Ingest spec
+```
+  nebula.bench:
+    max-mb: 10000
+    max-hr: 0
+    schema: "ROW<l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:int, l_extendedprice:float, l_discount:float, l_tax:float, l_returnflag:string, l_linestatus:string, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string>"
+    data: s3
+    loader: Swap
+    source: s3://pinlogs/nebula/bench1/
+    backup: s3://nebula/n109/
+    format: csv
+    columns:
+      l_returnflag:
+        dict: true
+      l_linestatus:
+        dict: true
+      l_shipinstruct:
+        dict: true
+      l_shipmode:
+        dict: true
+    time:
+      type: column
+      column: l_shipdate
+      pattern: "%Y-%m-%d"
+    settings:
+      csv.delimiter: "|"
+      csv.header: false
+```
+
+
+

--- a/dev.md
+++ b/dev.md
@@ -28,12 +28,11 @@ After you build nebula successfully, you can run this script to run all services
 ## Code Convention
 ### Style - use clang-format
 
-- VS Code is the default IDE which has extension for clang-format to format our code
-- install clang-format so that IDE can invoke the formatter automatically on saving.
-- https://packagecontrol.io/packages/Clang%20Format
-- On MacOS (npm install clang-format) and edit user-settings with below settings
-- "clang-format.executable": "/absolute-path-to/clang-format"
-- If you don't have npm on your mac, install node from here https://nodejs.org/en/download/
+- install clang-format (user dir): `npm install clang-format`
+- open preferences/settings `CMD+,`
+- enter value for "clang-format.executable": `~/node_modules/clang-format/bin/darwin_x64/clang-format`
+- check above path exists (it may change across versions depending on time run the installation)
+- my format key binding is `SHIFT+ALT+F` (check your own bindings)
 
 ### Basic Code Convention
 

--- a/dev.md
+++ b/dev.md
@@ -70,17 +70,11 @@ After you build nebula successfully, you can run this script to run all services
        2.  ./configure
        3.  sudo make install
    3.  use it in the app
-       1.  make nebula with -DGPROF=1 using "gprof"
-       2.  OR make nebula with -DPPROF=1 using "gperftools"
-       3.  Run Node server separately from other images by removing "node" service from docker-compose.yaml
-           1.  LD_PRELOAD=/usr/local/lib/libprofiler.so CPUPROFILE=/tmp/prof_ns.out CPUPROFILE_FREQUENCY=400 ./NodeServer
-       4.  if using gperftools, run NodeServer like this "LD_PRELOAD=/usr/local/lib/libprofiler.so CPUPROFILE=/tmp/prof_ns5.out ./NodeServer"
-           1.  A bit more info on using gperftools: https://gperftools.github.io/gperftools/cpuprofile.html
-           2.  to see reports with graph, install grpahviz "sudo apt-get install graphviz gv"
-           3.  then we can do "pprof --gv <bin> x.out"
-           4.  We can also (more practical since difficult to config gv on linux) gen svg file and copy it to mac to open by browsers.
-               1.  such as "pprof --svg NodeServer /tmp/prof_ns.out > prof.svg"
-       5.  if using gprof, run NodeServer normally
+       1.  make nebula with -DPPROF=1 using "gperftools"
+       2.  run NodeServer `LD_PRELOAD=/usr/local/lib/libprofiler.so CPUPROFILE=/tmp/prof_ns.out ./NodeServer`
+           1.  can add cpu frequency to tune the freuqency to profile `CPUPROFILE_FREQUENCY=400`
+           2.  to see reports with graph, install grpahviz `sudo apt-get install graphviz gv`
+           3.  convert: `pprof --svg NodeServer /tmp/prof_ns.out > prof.svg`
    4.  To make perfiler to flush/write perf results out, we need the app to exit normally. Hence implemented a hook to shutdown first node.
        1.  http://dev-shawncao:8088/?api=nuclear
 

--- a/src/api/dsl/Dsl.h
+++ b/src/api/dsl/Dsl.h
@@ -151,6 +151,11 @@ static InExpression<U> nin(const T& expr, nebula::common::Zip&& values) {
   return InExpression<U>(std::shared_ptr<Expression>(new T(expr)), std::move(values), false);
 }
 
+template <typename T, typename U>
+static BetweenExpression<U> between(const T& expr, const U&& min, const U&& max) {
+  return BetweenExpression<U>(std::shared_ptr<Expression>(new T(expr)), std::move(min), std::move(max));
+}
+
 template <typename T, typename std::enable_if_t<!IS_T_LITERAL(T), bool> = true>
 static ConstExpression<T> v(const T& value) {
   return ConstExpression<T>(value);

--- a/src/api/test/TestUdf.cpp
+++ b/src/api/test/TestUdf.cpp
@@ -20,6 +20,7 @@
 
 #include "api/dsl/Expressions.h"
 #include "api/udf/Avg.h"
+#include "api/udf/Between.h"
 #include "api/udf/Cardinality.h"
 #include "api/udf/Count.h"
 #include "api/udf/In.h"
@@ -183,6 +184,26 @@ TEST(UDFTest, TestPrefixContext) {
     auto result = prefix.eval(ctx);
     EXPECT_EQ(result, true);
   }
+}
+
+TEST(UDFTest, TestBetween) {
+  nebula::surface::MockAccessor row;
+  nebula::surface::eval::EvalContext ctx{ false };
+  ctx.reset(row);
+
+  auto count = 0;
+  for (auto i = 0; i < 20; ++i) {
+    auto c = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
+    nebula::api::udf::Between<nebula::type::Kind::INTEGER> between("b", c, 3, 8);
+    auto x = between.eval(ctx);
+    EXPECT_TRUE(x != std::nullopt);
+    if (x.value()) {
+      count++;
+    }
+  }
+
+  // 6 items in range [3, 8]
+  EXPECT_EQ(count, 6);
 }
 
 TEST(UDFTest, TestIn) {

--- a/src/api/test/TestUdf.cpp
+++ b/src/api/test/TestUdf.cpp
@@ -39,19 +39,17 @@ namespace test {
 using nebula::common::unordered_set;
 
 TEST(UDFTest, TestNot) {
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
   auto f = std::make_shared<nebula::api::dsl::ConstExpression<bool>>(false);
   nebula::api::udf::Not n("n", f->asEval());
-  bool valid = true;
-  EXPECT_EQ(n.eval(ctx, valid), true);
+  EXPECT_EQ(n.eval(ctx), true);
 
   auto t = std::make_shared<nebula::api::dsl::ConstExpression<bool>>(true);
   nebula::api::udf::Not y("n", t->asEval());
-  valid = true;
-  EXPECT_EQ(y.eval(ctx, valid), false);
+  EXPECT_EQ(y.eval(ctx), false);
 }
 
 TEST(UDFTest, TestLike) {
@@ -72,7 +70,7 @@ TEST(UDFTest, TestLike) {
     { "hi there", "%there", true },
     { "easy dessert pizza recipe", "%recipe%", true }
   };
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
@@ -83,8 +81,7 @@ TEST(UDFTest, TestLike) {
     LOG(INFO) << "Match " << s << " with " << p << " is " << r;
     auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(s);
     nebula::api::udf::Like l("l", c->asEval(), p);
-    bool valid = true;
-    EXPECT_EQ(l.eval(ctx, valid), r);
+    EXPECT_EQ(l.eval(ctx), r);
   }
 }
 
@@ -106,7 +103,7 @@ TEST(UDFTest, TestILike) {
     { "hi there", "%thEre", true },
     { "easy dessert pizza recipe", "%rEcIpe%", true }
   };
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
@@ -117,8 +114,7 @@ TEST(UDFTest, TestILike) {
     LOG(INFO) << "Match " << s << " with " << p << " is " << r;
     auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(s);
     nebula::api::udf::Like l("l", c->asEval(), p, false);
-    bool valid = true;
-    EXPECT_EQ(l.eval(ctx, valid), r);
+    EXPECT_EQ(l.eval(ctx), r);
   }
 }
 
@@ -133,7 +129,7 @@ TEST(UDFTest, TestPrefix) {
     { "hi there ", "i th", false },
     { "hi there", "hi there", true }
   };
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
@@ -144,8 +140,7 @@ TEST(UDFTest, TestPrefix) {
     LOG(INFO) << "Match " << s << " with " << p << " is " << r;
     auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(s);
     nebula::api::udf::Prefix prefix("p", c->asEval(), p);
-    bool valid = true;
-    EXPECT_EQ(prefix.eval(ctx, valid), r);
+    EXPECT_EQ(prefix.eval(ctx), r);
   }
 }
 
@@ -157,7 +152,7 @@ TEST(UDFTest, TestIPrefix) {
     { "NebUla is awesome", "neBulA", true },
     { "Hi there", "hI tHere", true }
   };
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
@@ -168,8 +163,7 @@ TEST(UDFTest, TestIPrefix) {
     LOG(INFO) << "Match " << s << " with " << p << " is " << r;
     auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(s);
     nebula::api::udf::Prefix prefix("p", c->asEval(), p, false);
-    bool valid = true;
-    EXPECT_EQ(prefix.eval(ctx, valid), r);
+    EXPECT_EQ(prefix.eval(ctx), r);
   }
 }
 
@@ -178,17 +172,15 @@ TEST(UDFTest, TestPrefixContext) {
     { "abcdefg", "abc", true },
   };
 
-  nebula::surface::MockRowData row;
+  nebula::surface::MockAccessor row;
   nebula::surface::eval::EvalContext ctx{ false };
   ctx.reset(row);
 
   auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>("abcdfeg");
   nebula::api::udf::Prefix prefix("p", c->asEval(), "abc");
   for (auto i = 0; i < 1000; ++i) {
-    bool valid = true;
     // auto result = prefix.eval(row, valid);
-    auto result = prefix.eval(ctx, valid);
-    EXPECT_EQ(valid, true);
+    auto result = prefix.eval(ctx);
     EXPECT_EQ(result, true);
   }
 }
@@ -206,7 +198,7 @@ TEST(UDFTest, TestIn) {
       { { "x", "y", "z" }, "z", false, false },
     };
 
-    nebula::surface::MockRowData row;
+    nebula::surface::MockAccessor row;
     nebula::surface::eval::EvalContext ctx{ false };
     ctx.reset(row);
 
@@ -220,12 +212,10 @@ TEST(UDFTest, TestIn) {
       auto c = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(t);
       if (f) {
         nebula::api::udf::In<nebula::type::Kind::VARCHAR> in("i", c, s);
-        bool valid = true;
-        EXPECT_EQ(in.eval(ctx, valid), r);
+        EXPECT_EQ(in.eval(ctx), r);
       } else {
         nebula::api::udf::In<nebula::type::Kind::VARCHAR> in("i", c, s, f);
-        bool valid = true;
-        EXPECT_EQ(in.eval(ctx, valid), r);
+        EXPECT_EQ(in.eval(ctx), r);
       }
     }
   }
@@ -242,7 +232,7 @@ TEST(UDFTest, TestIn) {
       { { 23, 34, 45, 56 }, 45, false, false },
     };
 
-    nebula::surface::MockRowData row;
+    nebula::surface::MockAccessor row;
     nebula::surface::eval::EvalContext ctx{ false };
     ctx.reset(row);
 
@@ -257,12 +247,10 @@ TEST(UDFTest, TestIn) {
       auto c = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(t);
       if (f) {
         nebula::api::udf::In<nebula::type::Kind::INTEGER> in("i", c, s);
-        bool valid = true;
-        EXPECT_EQ(in.eval(ctx, valid), r);
+        EXPECT_EQ(in.eval(ctx), r);
       } else {
         nebula::api::udf::In<nebula::type::Kind::INTEGER> in("i", c, s, f);
-        bool valid = true;
-        EXPECT_EQ(in.eval(ctx, valid), r);
+        EXPECT_EQ(in.eval(ctx), r);
       }
     }
   }
@@ -274,7 +262,6 @@ TEST(UDFTest, TestCount) {
 
   // simulate the run times 11 for c1 and 22 for c2
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid = false;
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(0);
   CType cf("count", v9->asEval());
   auto count1 = cf.sketch();
@@ -282,17 +269,16 @@ TEST(UDFTest, TestCount) {
   for (auto i = 0; i < 11; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ci("count1", vi->asEval());
-    auto v = ci.eval(ctx, invalid);
+    auto v = ci.eval(ctx);
     EXPECT_EQ(v, 1);
-    EXPECT_FALSE(invalid);
-    count1->merge(v);
+    count1->merge(v.value());
   }
 
   auto count2 = cf.sketch();
   for (auto i = 0; i < 22; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ci("count2", vi->asEval());
-    count2->merge(ci.eval(ctx, invalid));
+    count2->merge(ci.eval(ctx).value());
   }
 
   // partial merge
@@ -307,7 +293,6 @@ TEST(UDFTest, TestSum) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(0);
   using CType = nebula::api::udf::Sum<nebula::type::Kind::TINYINT>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType sf("sum", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -317,7 +302,7 @@ TEST(UDFTest, TestSum) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(i);
     CType si("sum1", vi->asEval());
 
-    sum1->merge(si.eval(ctx, invalid));
+    sum1->merge(si.eval(ctx).value());
     expected += i;
   }
 
@@ -326,7 +311,7 @@ TEST(UDFTest, TestSum) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(i);
     CType si("sum2", vi->asEval());
 
-    sum2->merge(si.eval(ctx, invalid));
+    sum2->merge(si.eval(ctx).value());
     expected += i;
   }
 
@@ -351,7 +336,6 @@ TEST(UDFTest, TestSum128) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(12);
   using CType = nebula::api::udf::Sum<nebula::type::Kind::INT128>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType sf("sum", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -361,7 +345,7 @@ TEST(UDFTest, TestSum128) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(i);
     CType si("sum1", vi->asEval());
 
-    sum1->merge(si.eval(ctx, invalid));
+    sum1->merge(si.eval(ctx).value());
     expected += i;
   }
 
@@ -370,7 +354,7 @@ TEST(UDFTest, TestSum128) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(i);
     CType si("sum2", vi->asEval());
 
-    sum2->merge(si.eval(ctx, invalid));
+    sum2->merge(si.eval(ctx).value());
     expected += i;
   }
 
@@ -387,7 +371,6 @@ TEST(UDFTest, TestMin) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(0);
   using CType = nebula::api::udf::Min<nebula::type::Kind::INTEGER>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType mf("min", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -397,7 +380,7 @@ TEST(UDFTest, TestMin) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType mi("min1", vi->asEval());
 
-    min1->merge(mi.eval(ctx, invalid));
+    min1->merge(mi.eval(ctx).value());
     expected = std::min(i, expected);
   }
 
@@ -406,7 +389,7 @@ TEST(UDFTest, TestMin) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType mi("min2", vi->asEval());
 
-    min2->merge(mi.eval(ctx, invalid));
+    min2->merge(mi.eval(ctx).value());
     expected = std::min(i, expected);
   }
 
@@ -423,7 +406,6 @@ TEST(UDFTest, TestMax) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(0);
   using CType = nebula::api::udf::Max<nebula::type::Kind::INTEGER>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType mf("max", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -433,7 +415,7 @@ TEST(UDFTest, TestMax) {
     int32_t v = i * -1;
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(v);
     CType mi("max1", vi->asEval());
-    max1->merge(mi.eval(ctx, invalid));
+    max1->merge(mi.eval(ctx).value());
     expected = std::max(v, expected);
   }
 
@@ -442,7 +424,7 @@ TEST(UDFTest, TestMax) {
     int32_t v = i * -1;
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(v);
     CType mi("max1", vi->asEval());
-    max2->merge(mi.eval(ctx, invalid));
+    max2->merge(mi.eval(ctx).value());
     expected = std::max(v, expected);
   }
 
@@ -460,7 +442,6 @@ TEST(UDFTest, TestAvg) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(0);
   using CType = nebula::api::udf::Avg<nebula::type::Kind::INTEGER>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType af("avg", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -471,7 +452,7 @@ TEST(UDFTest, TestAvg) {
   for (auto i = 0; i < 11; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ai("avg1", vi->asEval());
-    avg1->merge(ai.eval(ctx, invalid));
+    avg1->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -481,7 +462,7 @@ TEST(UDFTest, TestAvg) {
   for (auto i = 0; i < 22; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ai("avg2", vi->asEval());
-    avg2->merge(ai.eval(ctx, invalid));
+    avg2->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -500,7 +481,6 @@ TEST(UDFTest, TestAvgByte) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(0);
   using CType = nebula::api::udf::Avg<nebula::type::Kind::TINYINT>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType af("avg", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -509,9 +489,9 @@ TEST(UDFTest, TestAvgByte) {
 
   auto avg1 = af.sketch();
   for (auto i = 0; i < 127; ++i) {
-    auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
+    auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(i);
     CType ai("avg2", vi->asEval());
-    avg1->merge(ai.eval(ctx, invalid));
+    avg1->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -519,9 +499,9 @@ TEST(UDFTest, TestAvgByte) {
 
   auto avg2 = af.sketch();
   for (auto i = 0; i < 127; ++i) {
-    auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
+    auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int8_t>>(i);
     CType ai("avg2", vi->asEval());
-    avg2->merge(ai.eval(ctx, invalid));
+    avg2->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -539,7 +519,6 @@ TEST(UDFTest, TestAvgInt128) {
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(0);
   using CType = nebula::api::udf::Avg<nebula::type::Kind::INT128>;
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   CType af("avg", v9->asEval());
 
   // simulate the run times 11 for c1 and 22 for c2
@@ -550,7 +529,7 @@ TEST(UDFTest, TestAvgInt128) {
   for (auto i = 0; i < 127; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(i);
     CType ai("avg2", vi->asEval());
-    avg1->merge(ai.eval(ctx, invalid));
+    avg1->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -560,7 +539,7 @@ TEST(UDFTest, TestAvgInt128) {
   for (auto i = 0; i < 127; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int128_t>>(i);
     CType ai("avg2", vi->asEval());
-    avg2->merge(ai.eval(ctx, invalid));
+    avg2->merge(ai.eval(ctx).value());
 
     sum += i;
     count += 1;
@@ -579,7 +558,6 @@ TEST(UDFTest, TestPct) {
 
   // simulate the run times 11 for c1 and 22 for c2
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   auto v9 = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(0);
   double percentile = 99.0;
   CType tf("td1", v9->asEval(), percentile);
@@ -588,14 +566,14 @@ TEST(UDFTest, TestPct) {
   for (auto i = 0; i < 110; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ci("count1", vi->asEval(), percentile);
-    td1->merge(ci.eval(ctx, invalid));
+    td1->merge(ci.eval(ctx).value());
   }
 
   auto td2 = tf.sketch();
   for (auto i = 0; i < 220; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<int32_t>>(i);
     CType ci("count2", vi->asEval(), percentile);
-    td2->merge(ci.eval(ctx, invalid));
+    td2->merge(ci.eval(ctx).value());
   }
 
   // partial merge
@@ -621,7 +599,6 @@ TEST(UDFTest, TestTpm) {
 
   // simulate the run times 11 for c1 and 22 for c2
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   auto v1 = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>("");
   CType tpm("tmp1", v1->asEval());
 
@@ -629,14 +606,14 @@ TEST(UDFTest, TestTpm) {
   for (size_t i = 0, size = std::size(stacks); i < size; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(stacks[i]);
     CType ci("tmp", vi->asEval());
-    sketch->merge(ci.eval(ctx, invalid));
+    sketch->merge(ci.eval(ctx).value());
   }
 
   auto sketch2 = tpm.sketch();
   for (size_t i = 0, size = std::size(stacks); i < size; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(stacks[i]);
     CType ci("tmp2", vi->asEval());
-    sketch2->merge(ci.eval(ctx, invalid));
+    sketch2->merge(ci.eval(ctx).value());
   }
 
   // partial merge
@@ -739,7 +716,6 @@ TEST(UDFTest, TestCardinality) {
 
   // simulate the run times 11 for c1 and 22 for c2
   nebula::surface::eval::EvalContext ctx{ false };
-  bool invalid;
   auto v1 = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>("");
   CType card("tmp1", v1->asEval());
 
@@ -747,14 +723,14 @@ TEST(UDFTest, TestCardinality) {
   for (size_t i = 0, size = std::size(stacks); i < size; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(stacks[i]);
     CType ci("tmp", vi->asEval());
-    sketch->merge(ci.eval(ctx, invalid));
+    sketch->merge(ci.eval(ctx).value());
   }
 
   auto sketch2 = card.sketch();
   for (size_t i = 0, size = std::size(stacks); i < size; ++i) {
     auto vi = std::make_shared<nebula::api::dsl::ConstExpression<std::string_view>>(stacks[i]);
     CType ci("tmp2", vi->asEval());
-    sketch2->merge(ci.eval(ctx, invalid));
+    sketch2->merge(ci.eval(ctx).value());
   }
 
   // partial merge

--- a/src/api/test/TestUdf.cpp
+++ b/src/api/test/TestUdf.cpp
@@ -187,7 +187,7 @@ TEST(UDFTest, TestPrefixContext) {
   for (auto i = 0; i < 1000; ++i) {
     bool valid = true;
     // auto result = prefix.eval(row, valid);
-    auto result = ctx.eval<bool>(prefix, valid);
+    auto result = prefix.eval(ctx, valid);
     EXPECT_EQ(valid, true);
     EXPECT_EQ(result, true);
   }

--- a/src/api/udf/In.h
+++ b/src/api/udf/In.h
@@ -46,8 +46,12 @@ public:
       name,
       expr->asEval(),
       // logic for "in []"
-      [values](const InputType& source, bool& valid) -> bool {
-        return valid && values->find(source) != values->end();
+      [values](const std::optional<InputType>& source) -> bool {
+        if (UNLIKELY(source == std::nullopt)) {
+          return false;
+        }
+
+        return values->find(source.value()) != values->end();
       },
       buildEvalBlock(expr, values, true)) {}
 
@@ -59,8 +63,12 @@ public:
       name,
       expr->asEval(),
       // logic for "not in []"
-      [values](const InputType& source, bool& valid) -> bool {
-        return valid && values->find(source) == values->end();
+      [values](const std::optional<InputType>& source) -> bool {
+        if (UNLIKELY(source == std::nullopt)) {
+          return false;
+        }
+
+        return values->find(source.value()) == values->end();
       },
       buildEvalBlock(expr, values, false)) {
     N_ENSURE(!in, "this constructor is designed for NOT IN clauase");

--- a/src/api/udf/Like.h
+++ b/src/api/udf/Like.h
@@ -55,13 +55,13 @@ public:
     : UdfLikeBase(
       name,
       std::move(expr),
-      [pattern, caseSensitive](const std::optional<InputType>& source) -> NativeType {
-        if (LIKELY(source != std::nullopt)) {
-          auto v = source.value();
-          return match(v.data(), v.size(), 0, pattern.data(), pattern.size(), 0, caseSensitive);
+      [pattern, caseSensitive](const std::optional<InputType>& source) -> std::optional<NativeType> {
+        if (UNLIKELY(source == std::nullopt)) {
+          return std::nullopt;
         }
 
-        return false;
+        auto v = source.value();
+        return match(v.data(), v.size(), 0, pattern.data(), pattern.size(), 0, caseSensitive);
       }) {}
   virtual ~Like() = default;
 };

--- a/src/api/udf/Like.h
+++ b/src/api/udf/Like.h
@@ -53,15 +53,16 @@ public:
        const std::string& pattern,
        bool caseSensitive = true)
     : UdfLikeBase(
-        name,
-        std::move(expr),
-        [pattern, caseSensitive](const InputType& source, bool& valid) -> NativeType {
-          if (valid) {
-            return match(source.data(), source.size(), 0, pattern.data(), pattern.size(), 0, caseSensitive);
-          }
+      name,
+      std::move(expr),
+      [pattern, caseSensitive](const std::optional<InputType>& source) -> NativeType {
+        if (LIKELY(source != std::nullopt)) {
+          auto v = source.value();
+          return match(v.data(), v.size(), 0, pattern.data(), pattern.size(), 0, caseSensitive);
+        }
 
-          return false;
-        }) {}
+        return false;
+      }) {}
   virtual ~Like() = default;
 };
 

--- a/src/api/udf/Not.h
+++ b/src/api/udf/Not.h
@@ -34,9 +34,9 @@ public:
     : UdfNotBase(
       name,
       std::move(expr),
-      [](const std::optional<NativeType>& origin) {
-        if (origin == std::nullopt) {
-          return true;
+      [](const std::optional<NativeType>& origin) -> std::optional<bool> {
+        if (UNLIKELY(origin == std::nullopt)) {
+          return std::nullopt;
         }
 
         // otherwise reverse

--- a/src/api/udf/Not.h
+++ b/src/api/udf/Not.h
@@ -32,16 +32,16 @@ class Not : public UdfNotBase {
 public:
   Not(const std::string& name, std::unique_ptr<nebula::surface::eval::ValueEval> expr)
     : UdfNotBase(
-        name,
-        std::move(expr),
-        [](const NativeType& origin, bool& valid) {
-          if (!valid) {
-            return true;
-          }
+      name,
+      std::move(expr),
+      [](const std::optional<NativeType>& origin) {
+        if (origin == std::nullopt) {
+          return true;
+        }
 
-          // otherwise reverse
-          return !origin;
-        }) {}
+        // otherwise reverse
+        return !origin.value();
+      }) {}
   virtual ~Not() = default;
 };
 

--- a/src/api/udf/Prefix.h
+++ b/src/api/udf/Prefix.h
@@ -43,14 +43,14 @@ public:
     : UdfPrefixBase(
       name,
       std::move(expr),
-      [prefix, caseSensitive](const std::optional<InputType>& source) -> NativeType {
-        if (source) {
-          auto v = source.value();
-          return nebula::common::Chars::prefix(
-            v.data(), v.size(), prefix.data(), prefix.size(), !caseSensitive);
+      [prefix, caseSensitive](const std::optional<InputType>& source) -> std::optional<NativeType> {
+        if (UNLIKELY(source == std::nullopt)) {
+          return std::nullopt;
         }
 
-        return false;
+        auto v = source.value();
+        return nebula::common::Chars::prefix(
+          v.data(), v.size(), prefix.data(), prefix.size(), !caseSensitive);
       }) {}
   virtual ~Prefix() = default;
 };

--- a/src/api/udf/Prefix.h
+++ b/src/api/udf/Prefix.h
@@ -43,10 +43,11 @@ public:
     : UdfPrefixBase(
       name,
       std::move(expr),
-      [prefix, caseSensitive](const InputType& source, bool& valid) -> NativeType {
-        if (valid) {
+      [prefix, caseSensitive](const std::optional<InputType>& source) -> NativeType {
+        if (source) {
+          auto v = source.value();
           return nebula::common::Chars::prefix(
-            source.data(), source.size(), prefix.data(), prefix.size(), !caseSensitive);
+            v.data(), v.size(), prefix.data(), prefix.size(), !caseSensitive);
         }
 
         return false;

--- a/src/api/udf/UDFFactory.h
+++ b/src/api/udf/UDFFactory.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "Avg.h"
+#include "Between.h"
 #include "Cardinality.h"
 #include "Count.h"
 #include "In.h"
@@ -95,6 +96,10 @@ public:
 
     if constexpr (UKIND == UDFKind::IN) {
       return std::make_unique<In<IK>>(name, expr, std::forward<Args>(args)...);
+    }
+
+    if constexpr (UKIND == UDFKind::BETWEEN) {
+      return std::make_unique<Between<IK>>(name, expr, std::forward<Args>(args)...);
     }
 
     throw NException(fmt::format("Unimplemented UDF {0}", name));

--- a/src/common/Errors.h
+++ b/src/common/Errors.h
@@ -18,6 +18,8 @@
 
 #include <fmt/format.h>
 
+#include "Likely.h"
+
 namespace nebula {
 namespace common {
 
@@ -71,12 +73,14 @@ static constexpr cstr lslash(cstr str) {
 
 #define THROW_IF_NOT_EXP(EXP, MSG)                                       \
   ({                                                                     \
-    if (!(EXP)) {                                                        \
+    if (UNLIKELY(!(EXP))) {                                              \
       throw NException(fmt::format("[Violation: {0}]: {1}", #EXP, MSG)); \
     }                                                                    \
   })
 
 #define N_ENSURE(e, msg) THROW_IF_NOT_EXP(e, msg)
+
+#define N_ENSURE_NULL(p, m) THROW_IF_NOT_EXP(p == nullptr, m)
 
 #define N_ENSURE_NOT_NULL(p, m) THROW_IF_NOT_EXP(p != nullptr, m)
 

--- a/src/common/Evidence.h
+++ b/src/common/Evidence.h
@@ -47,16 +47,25 @@ public: /** only static methods */
   static constexpr auto MICRO_BASE = 1000'000'000'000'000;
   static constexpr auto MILLI_BASE = 1000'000'000'000;
 
+  // micro-seconds
   inline static size_t ticks() {
     return std::chrono::system_clock::now().time_since_epoch().count();
+  }
+
+  template <typename T>
+  inline static size_t seconds(const std::chrono::time_point<T>& tp) {
+    return std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
+  }
+
+  template <typename T>
+  inline static size_t seconds(const std::chrono::duration<T>& dur) {
+    return std::chrono::duration_cast<std::chrono::seconds>(dur).count();
   }
 
   // TODO(cao): consider using int64_t rather than size_t
   // to support time before unix epoch (1970)
   inline static size_t unix_timestamp() {
-    return std::chrono::duration_cast<std::chrono::seconds>(
-             std::chrono::system_clock::now().time_since_epoch())
-      .count();
+    return seconds(std::chrono::system_clock::now());
   }
 
   // convert a serial number to unix timestamp (seconds)

--- a/src/common/test/TestCommon.cpp
+++ b/src/common/test/TestCommon.cpp
@@ -380,6 +380,34 @@ inline bool f1ni(int i) {
   return i % 2 == 0;
 }
 
+TEST(CommonTest, TestOptionalBool) {
+  std::optional<int32_t> x = 0;
+  std::optional<int8_t> y = x;
+  EXPECT_TRUE(x);
+  EXPECT_TRUE(y);
+
+  auto f0 = []() -> std::optional<int8_t> {
+    return 0;
+  };
+  EXPECT_FALSE(!f0());
+
+  auto f1 = []() -> std::optional<bool> {
+    return std::nullopt;
+  };
+  EXPECT_EQ(f1(), std::nullopt);
+  EXPECT_FALSE(f1());
+
+  auto f2 = []() -> std::optional<bool> {
+    return false;
+  };
+  EXPECT_EQ(f2(), false);
+
+  auto f3 = []() -> std::optional<bool> {
+    return true;
+  };
+  EXPECT_EQ(f3(), true);
+}
+
 TEST(CommonTest, TestOptionalPerf) {
   // use -1 indicating null
   // auto f1n = [](int i) -> bool {

--- a/src/common/test/TestCommon.cpp
+++ b/src/common/test/TestCommon.cpp
@@ -797,23 +797,23 @@ TEST(CommonTest, TestWriteAlign) {
   EXPECT_EQ(v, v2);
 }
 
-struct B {
-  B() {
+struct SimpleB {
+  SimpleB() {
     LOG(INFO) << "CONSTRUCT B";
   }
-  virtual ~B() {
+  virtual ~SimpleB() {
     LOG(INFO) << "DESTRUCT B";
   }
 };
-struct S : public B {
-  S() {
+struct SimpleS : public SimpleB {
+  SimpleS() {
     LOG(INFO) << "CONSTRUCT S";
   }
-  ~S() = default;
+  ~SimpleS() = default;
 };
 
 TEST(CommonTest, TestConstructDestructOrder) {
-  auto s = std::make_unique<S>();
+  auto s = std::make_unique<SimpleS>();
   LOG(INFO) << (s != nullptr);
   s = nullptr;
   LOG(INFO) << "destructor already called";

--- a/src/common/test/TestExts.cpp
+++ b/src/common/test/TestExts.cpp
@@ -174,23 +174,23 @@ TEST(CuckooTest, TestCuckooFilter) {
 }
 
 // Testing yomm2 open multi-methods
-struct A {
-  virtual ~A() {}
+struct MMA {
+  virtual ~MMA() {}
 };
-struct B : A {};
-struct C : A {};
+struct MMB : MMA {};
+struct MMC : MMA {};
 
-register_class(A);
-register_class(B, A);
-register_class(C, A);
+register_class(MMA);
+register_class(MMB, MMA);
+register_class(MMC, MMA);
 
-declare_method(std::string, foobar, (yorel::yomm2::virtual_<A&>));
+declare_method(std::string, foobar, (yorel::yomm2::virtual_<MMA&>));
 
-define_method(std::string, foobar, (A&)) {
+define_method(std::string, foobar, (MMA&)) {
   return "foobar(A)";
 }
 
-define_method(std::string, foobar, (B&)) {
+define_method(std::string, foobar, (MMB&)) {
   return "foobar(B)";
 }
 
@@ -202,8 +202,8 @@ TEST(CommonTest, TestOmm) {
   yorel::yomm2::update_methods();
 
   // NOTE: multi-inheritence may not work as tested.
-  B b;
-  C c;
+  MMB b;
+  MMC c;
   LOG(INFO) << foobar(b);
   LOG(INFO) << foobar(c);
 }

--- a/src/configs/bench.yml
+++ b/src/configs/bench.yml
@@ -1,0 +1,51 @@
+version: 1.0
+
+# server configs
+server:
+  # as node will treat server to run as a node
+  # if false, server will not load any data in itself.
+  # NOTE that, there are maybe missing functions to fully compatible for server as node.
+  # such as task execution may not be implemented.
+  anode: false
+  auth: false
+
+  meta:
+    db: native
+    store: s3://nebula/meta/
+
+  discovery:
+    method: config
+
+# will be provided by enviroment
+nodes:
+  - node:
+      host: localhost
+      port: 9199
+
+tables:
+  nebula.bench:
+    max-mb: 10000
+    max-hr: 0
+    schema: "ROW<l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:int, l_extendedprice:float, l_discount:float, l_tax:float, l_returnflag:tinyint, l_linestatus:tinyint, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string>"
+    data: local
+    loader: Swap
+    # TPC-H dataset - decompressed to local for benchmark test
+    source: /home/shawncao/nebula/build/lineitem.tbl.1
+    backup: s3://nebula/n109/
+    format: csv
+    columns:
+      l_shipinstruct:
+        dict: true
+      l_shipmode:
+        dict: true
+      l_commitdate:
+        dict: true
+      l_receiptdate:
+        dict: true
+    time:
+      type: column
+      column: l_shipdate
+      pattern: "%Y-%m-%d"
+    settings:
+      csv.delimiter: "|"
+      csv.header: false

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -23,28 +23,19 @@ nodes:
       port: 9199
 
 tables:
-  nebula.bench:
+  nebula.test:
     max-mb: 10000
-    max-hr: 0
-    schema: "ROW<l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:int, l_extendedprice:float, l_discount:float, l_tax:float, l_returnflag:tinyint, l_linestatus:tinyint, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string>"
-    data: local
-    loader: Swap
-    source: /home/shawncao/nebula/build/lineitem.tbl.1
-    backup: s3://nebula/n109/
-    format: csv
-    columns:
-      l_shipinstruct:
-        dict: true
-      l_shipmode:
-        dict: true
-      l_commitdate:
-        dict: true
-      l_receiptdate:
-        dict: true
-    time:
-      type: column
-      column: l_shipdate
-      pattern: "%Y-%m-%d"
+    max-hr: 240
+    schema: "ROW<id:int, event:string, items:list<string>, flag:bool, value:tinyint>"
+    data: custom
+    loader: NebulaTest
+    source: ""
+    backup: s3://nebula/n100/
+    format: none
     settings:
-      csv.delimiter: "|"
-      csv.header: false
+      key1: value1
+      key2: value2
+    time:
+      type: static
+      # get it from linux by "date +%s"
+      value: 1565994194

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -23,46 +23,32 @@ nodes:
       port: 9199
 
 tables:
-  nebula.test:
-    # max 10G RAM assigment
+  nebula.bench:
     max-mb: 10000
-    # max 10 days assignment
-    max-hr: 240
-    schema: "ROW<id:int, event:string, items:list<string>, flag:bool, value:tinyint>"
-    data: custom
-    loader: NebulaTest
-    source: ""
-    backup: s3://nebula/n100/
-    format: none
-    settings:
-      key1: value1
-      key2: value2
-    time:
-      type: static
-      # get it from linux by "date +%s"
-      value: 1565994194
-  nebula.ephemeral:
-    # size and time may not be respected - ephemeral
-    max-mb: 10000
-    max-hr: 1
-    schema: "ROW<actor_id:string, pin_id:bigint, partner_id:bigint, ct:bigint, app:string, domain:string, url:string, image_signature:string, root_pin_id:bigint, is_video:boolean, board_id:bigint, publish_type:int, create_date_ts:bigint, country:string, metro:int, gender:tinyint, age:smallint, custom_tag:int>"
-    data: s3
-    loader: Api
-    # parameterized data source for on-demand loading, all parameters are formed by {}
-    # this example template has these parameters {date}, {ds}, {ct}, {pf}, {et}, {bucket}
-    source: s3://nebula/ephemeral/dt=%7Bdate%7D/downstream=%7Bds%7D/contenttype=%7Bct%7D/pinformat=%7Bpf%7D/eventtype=%7Bet%7D/part-r-{%7Bbucket%7D}-fb7ea820-76a3-4c60-be79-956727df7593.gz.parquet
-    # this is a bucket table, so it will have a bucket macro to be fullfiled
-    # this table bucketed by partner_id into 10K buckets
-    bucket:
-      size: 10000
-      column: partner_id
-    backup: s3://nebula/n200/
-    format: parquet
+    max-hr: 0
+    schema: "ROW<l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:int, l_extendedprice:float, l_discount:float, l_tax:float, l_returnflag:tinyint, l_linestatus:tinyint, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string>"
+    data: local
+    loader: Swap
+    source: /Users/shawncao/nebula/build/lineitem.tbl.1
+    backup: s3://nebula/n109/
+    format: csv
     columns:
-      app:
+      l_returnflag:
         dict: true
-      country:
+      l_linestatus:
+        dict: true
+      l_shipinstruct:
+        dict: true
+      l_shipmode:
+        dict: true
+      l_commitdate:
+        dict: true
+      l_receiptdate:
         dict: true
     time:
-      type: macro
-      pattern: date
+      type: column
+      column: l_shipdate
+      pattern: "%Y-%m-%d"
+    settings:
+      csv.delimiter: "|"
+      csv.header: false

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -29,14 +29,10 @@ tables:
     schema: "ROW<l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:int, l_extendedprice:float, l_discount:float, l_tax:float, l_returnflag:tinyint, l_linestatus:tinyint, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string>"
     data: local
     loader: Swap
-    source: /Users/shawncao/nebula/build/lineitem.tbl.1
+    source: /home/shawncao/nebula/build/lineitem.tbl.1
     backup: s3://nebula/n109/
     format: csv
     columns:
-      l_returnflag:
-        dict: true
-      l_linestatus:
-        dict: true
       l_shipinstruct:
         dict: true
       l_shipmode:

--- a/src/execution/Execution.cmake
+++ b/src/execution/Execution.cmake
@@ -32,7 +32,8 @@ target_link_libraries(${NEBULA_EXEC}
     PUBLIC ${ROARING_LIBRARY}
     PUBLIC ${JSON_LIBRARY}
     PUBLIC ${OMM_LIBRARY}
-    PUBLIC ${Boost_regex_LIBRARY})
+    PUBLIC ${Boost_regex_LIBRARY}
+    PUBLIC ${PERF_LIBRARY})
 
 # build test binary
 add_executable(ExecTests

--- a/src/execution/core/BlockExecutor.cpp
+++ b/src/execution/core/BlockExecutor.cpp
@@ -16,9 +16,16 @@
 
 #include "BlockExecutor.h"
 
+#include <gflags/gflags.h>
+#include <gperftools/profiler.h>
+
 #include "AggregationMerge.h"
+#include "common/Likely.h"
 #include "memory/keyed/HashFlat.h"
 #include "surface/eval/UDF.h"
+
+DEFINE_bool(CPU_PROF, false, "Enable cpu profile");
+DEFINE_string(PROF_FILE, "/tmp/cpu_prof.out", "CPU profile output file");
 
 /**
  * Nebula runtime / online meta data.
@@ -48,6 +55,11 @@ RowCursorPtr compute(const EvaledBlock& data, const nebula::execution::BlockPhas
 }
 
 void BlockExecutor::compute() {
+  // instrumentation for profiling on compute branch
+  if (UNLIKELY(FLAGS_CPU_PROF)) {
+    ProfilerStart(FLAGS_PROF_FILE.c_str());
+  }
+
   // process every single row and put result in HashFlat
   auto accessor = data_.first->makeAccessor();
   const auto& fields = plan_.fields();
@@ -84,7 +96,7 @@ void BlockExecutor::compute() {
     // ignore valid here - if system can't determine how to act on NULL value
     // we don't know how to make decision here too
     bool valid = true;
-    if (!scanAll && !ctx->eval<bool>(filter, valid)) {
+    if (!scanAll && !filter.eval<bool>(*ctx, valid)) {
       continue;
     }
 
@@ -95,6 +107,10 @@ void BlockExecutor::compute() {
   // after the compute flat should contain all the data we need.
   index_ = 0;
   size_ = result_->getRows();
+
+  if (UNLIKELY(FLAGS_CPU_PROF)) {
+    ProfilerStop();
+  }
 }
 
 void SamplesExecutor::compute() {

--- a/src/execution/core/BlockExecutor.cpp
+++ b/src/execution/core/BlockExecutor.cpp
@@ -95,9 +95,10 @@ void BlockExecutor::compute() {
     // if not fullfil the condition
     // ignore valid here - if system can't determine how to act on NULL value
     // we don't know how to make decision here too
-    bool valid = true;
-    if (!scanAll && !filter.eval<bool>(*ctx, valid)) {
-      continue;
+    if (LIKELY(!scanAll)) {
+      if (!filter.eval<bool>(*ctx).value_or(false)) {
+        continue;
+      }
     }
 
     // flat compute every new value of each field and set to corresponding column in flat

--- a/src/execution/core/ComputedRow.cpp
+++ b/src/execution/core/ComputedRow.cpp
@@ -28,12 +28,11 @@ bool ComputedRow::isNull(IndexType) const {
   return false;
 }
 
-// TODO(cao) - need to implement isNull (maybe cache to ensure evaluate once)
+// TODO(cao) - need to use the consistent interface of optional<T>
 // otherwise - this may return invalid values
-#define FORWARD_EVAL_FIELD(TYPE, NAME)               \
-  TYPE ComputedRow::NAME(IndexType index) const {    \
-    bool valid = true;                               \
-    return fields_[index]->eval<TYPE>(*ctx_, valid); \
+#define FORWARD_EVAL_FIELD(TYPE, NAME)                                                        \
+  TYPE ComputedRow::NAME(IndexType index) const {                                             \
+    return fields_[index]->eval<TYPE>(*ctx_).value_or(nebula::type::TypeDetect<TYPE>::value); \
   }
 
 FORWARD_EVAL_FIELD(bool, readBool)

--- a/src/execution/core/ComputedRow.cpp
+++ b/src/execution/core/ComputedRow.cpp
@@ -33,7 +33,7 @@ bool ComputedRow::isNull(IndexType) const {
 #define FORWARD_EVAL_FIELD(TYPE, NAME)               \
   TYPE ComputedRow::NAME(IndexType index) const {    \
     bool valid = true;                               \
-    return ctx_->eval<TYPE>(*fields_[index], valid); \
+    return fields_[index]->eval<TYPE>(*ctx_, valid); \
   }
 
 FORWARD_EVAL_FIELD(bool, readBool)

--- a/src/execution/core/ReferenceRows.h
+++ b/src/execution/core/ReferenceRows.h
@@ -83,8 +83,7 @@ private:
     // if not fullfil the condition
     // ignore valid here - if system can't determine how to act on NULL value
     // we don't know how to make decision here too
-    bool valid = true;
-    if (!filter_.eval<bool>(*ctx_, valid) || !valid) {
+    if (!filter_.eval<bool>(*ctx_).value_or(false)) {
       return size_;
     }
 

--- a/src/execution/core/ReferenceRows.h
+++ b/src/execution/core/ReferenceRows.h
@@ -84,7 +84,7 @@ private:
     // ignore valid here - if system can't determine how to act on NULL value
     // we don't know how to make decision here too
     bool valid = true;
-    if (!ctx_->eval<bool>(filter_, valid) || !valid) {
+    if (!filter_.eval<bool>(*ctx_, valid) || !valid) {
       return size_;
     }
 

--- a/src/execution/test/TestExec.cpp
+++ b/src/execution/test/TestExec.cpp
@@ -35,6 +35,7 @@ namespace test {
 using nebula::execution::core::BlockExecutor;
 using nebula::memory::Batch;
 using nebula::memory::EvaledBlock;
+using nebula::surface::Accessor;
 using nebula::surface::MockRowData;
 using nebula::surface::RowData;
 using nebula::surface::eval::BlockEval;
@@ -50,6 +51,12 @@ static constexpr auto line = [](const RowData& r) {
                      r.isNull("id") ? 0 : r.readInt("id"),
                      r.isNull("event") ? "NULL" : r.readString("event"),
                      r.isNull("flag") ? true : r.readBool("flag"));
+};
+static constexpr auto line2 = [](const Accessor& r) {
+  return fmt::format("({0}, {1}, {2})",
+                     r.readInt("id").value_or(0),
+                     r.readString("event").value_or("NULL"),
+                     r.readBool("flag").value_or(true));
 };
 
 class TestUdaf : public UDAF<nebula::type::Kind::INTEGER> {
@@ -161,8 +168,8 @@ TEST(ExecutionTest, TestRowCursorSerde) {
     for (auto i = 0; i < size; ++i) {
       const auto& rb = accessor->seek(i);
       const auto& rf = fb->row(i);
-      EXPECT_EQ(line(rb), line(rf));
-      LOG(INFO) << "verify row: " << i << ", b=" << line(rb) << ",f=" << line(rf);
+      EXPECT_EQ(line2(rb), line(rf));
+      LOG(INFO) << "verify row: " << i << ", b=" << line2(rb) << ",f=" << line(rf);
     }
   }
 

--- a/src/execution/test/TestValueEvalTree.cpp
+++ b/src/execution/test/TestValueEvalTree.cpp
@@ -278,7 +278,7 @@ TEST(ValueEvalTest, TestEvaluationContext) {
     LOG(INFO) << "signature of b5=" << b5->signature();
     for (auto i = 0; i < 1000; ++i) {
       EXPECT_EQ(valid, true);
-      EXPECT_EQ(ctx.eval<bool>(*b5, valid), false);
+      EXPECT_EQ(b5->eval<bool>(ctx, valid), false);
     }
   }
 
@@ -292,7 +292,7 @@ TEST(ValueEvalTest, TestEvaluationContext) {
     bool valid = true;
     ctx.reset(row);
     for (auto i = 0; i < 1000; ++i) {
-      auto result = ctx.eval<bool>(*b5, valid);
+      auto result = b5->eval<bool>(ctx, valid);
       EXPECT_EQ(valid, true);
       EXPECT_EQ(result, true);
     }
@@ -308,7 +308,7 @@ TEST(ValueEvalTest, TestEvaluationContext) {
     ctx.reset(row);
     for (auto i = 0; i < 1000; ++i) {
       bool valid = true;
-      auto result = ctx.eval<bool>(*b5, valid);
+      auto result = b5->eval<bool>(ctx, valid);
       EXPECT_EQ(valid, false);
       if (valid) {
         EXPECT_EQ(result, true);

--- a/src/execution/test/TestValueEvalTree.cpp
+++ b/src/execution/test/TestValueEvalTree.cpp
@@ -39,14 +39,13 @@ using nebula::surface::eval::gt;
 using nebula::surface::eval::TypeValueEval;
 using nebula::surface::eval::ValueEval;
 
-class MockRow : public nebula::surface::MockRowData {
+class MockRow : public nebula::surface::MockAccessor {
 public:
   MockRow() = default;
-  MOCK_CONST_METHOD1(readBool, bool(const std::string&));
-  MOCK_CONST_METHOD1(readInt, int32_t(const std::string&));
-  MOCK_CONST_METHOD1(readFloat, float(const std::string&));
-  MOCK_CONST_METHOD1(readString, std::string_view(const std::string&));
-  MOCK_CONST_METHOD1(isNull, bool(const std::string&));
+  MOCK_CONST_METHOD1(readBool, std::optional<bool>(const std::string&));
+  MOCK_CONST_METHOD1(readInt, std::optional<int32_t>(const std::string&));
+  MOCK_CONST_METHOD1(readFloat, std::optional<float>(const std::string&));
+  MOCK_CONST_METHOD1(readString, std::optional<std::string_view>(const std::string&));
 };
 
 TEST(ValueEvalTest, TestValueEval) {
@@ -54,35 +53,30 @@ TEST(ValueEvalTest, TestValueEval) {
   MockRow row;
   EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
   EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(ivalue));
-  EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
   // int = 3 + col('a')
   EvalContext ctx{ false };
   ctx.reset(row);
   auto b1 = nebula::surface::eval::constant(ivalue);
-  bool valid = true;
-  auto v1 = b1->eval<int>(ctx, valid);
-  LOG(INFO) << "b1 eval: " << v1 << ", valid:" << valid;
+  auto v1 = b1->eval<int>(ctx);
+  LOG(INFO) << "b1 eval: " << v1.value();
   EXPECT_EQ(v1, ivalue);
 
   auto b2 = nebula::surface::eval::column<int>("a");
 
-  valid = true;
-  auto v2 = b2->eval<int>(ctx, valid);
-  LOG(INFO) << "b2 eval: " << v2;
+  auto v2 = b2->eval<int>(ctx);
+  LOG(INFO) << "b2 eval: " << v2.value();
   EXPECT_EQ(v1, v2);
 
   auto b3 = nebula::surface::eval::add<int, int, int>(std::move(b1), std::move(b2));
-  valid = true;
-  auto sum = b3->eval<int>(ctx, valid);
-  auto expected_sum = v1 + v2;
-  LOG(INFO) << "b3 eval: " << sum;
+  auto sum = b3->eval<int>(ctx);
+  auto expected_sum = v1.value() + v2.value();
+  LOG(INFO) << "b3 eval: " << sum.value();
   EXPECT_EQ(sum, expected_sum);
 
   auto b4 = nebula::surface::eval::constant(ivalue);
   auto b5 = nebula::surface::eval::lt<int, int>(std::move(b3), std::move(b4));
-  valid = true;
-  EXPECT_FALSE(b5->eval<bool>(ctx, valid));
+  EXPECT_EQ(b5->eval<bool>(ctx), false);
 }
 
 TEST(ValueEvalTest, TestValueEvalArthmetic) {
@@ -93,7 +87,6 @@ TEST(ValueEvalTest, TestValueEvalArthmetic) {
     EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(cvalue));
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(cvalue));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     EvalContext ctx{ false };
     ctx.reset(row);
@@ -101,9 +94,8 @@ TEST(ValueEvalTest, TestValueEvalArthmetic) {
     auto b1 = nebula::surface::eval::constant(cvalue);
     auto b2 = nebula::surface::eval::column<float>("x");
     auto b3 = nebula::surface::eval::add<float, int, float>(std::move(b1), std::move(b2));
-    bool valid = true;
-    float add = b3->eval<float>(ctx, valid);
-    EXPECT_EQ(add, row.readFloat("x") + cvalue);
+    auto add = b3->eval<float>(ctx);
+    EXPECT_EQ(add, row.readFloat("x").value() + cvalue);
   }
 
   {
@@ -112,16 +104,14 @@ TEST(ValueEvalTest, TestValueEvalArthmetic) {
     EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(cvalue));
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(cvalue));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     EvalContext ctx{ false };
     ctx.reset(row);
     auto b1 = nebula::surface::eval::constant(cvalue);
     auto b2 = nebula::surface::eval::column<float>("y");
     auto b3 = nebula::surface::eval::mul<float, int, float>(std::move(b1), std::move(b2));
-    bool valid = true;
-    float mul = b3->eval<float>(ctx, valid);
-    EXPECT_EQ(mul, row.readFloat("y") * cvalue);
+    auto mul = b3->eval<float>(ctx);
+    EXPECT_EQ(mul, row.readFloat("y").value() * cvalue);
   }
 
   {
@@ -130,16 +120,14 @@ TEST(ValueEvalTest, TestValueEvalArthmetic) {
     EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(cvalue));
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(cvalue));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     EvalContext ctx{ false };
     ctx.reset(row);
     auto b1 = nebula::surface::eval::constant(cvalue);
     auto b2 = nebula::surface::eval::column<float>("z");
     auto b3 = nebula::surface::eval::sub<float, int, float>(std::move(b1), std::move(b2));
-    bool valid = true;
-    float sub = b3->eval<float>(ctx, valid);
-    EXPECT_EQ(sub, cvalue - row.readFloat("z"));
+    auto sub = b3->eval<float>(ctx);
+    EXPECT_EQ(sub, cvalue - row.readFloat("z").value());
   }
 
   {
@@ -148,16 +136,14 @@ TEST(ValueEvalTest, TestValueEvalArthmetic) {
     EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(cvalue));
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(cvalue));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     EvalContext ctx{ false };
     ctx.reset(row);
     auto b1 = nebula::surface::eval::constant(cvalue);
     auto b2 = nebula::surface::eval::column<float>("d");
     auto b3 = nebula::surface::eval::div<float, float, int>(std::move(b2), std::move(b1));
-    bool valid = true;
-    float div = b3->eval<float>(ctx, valid);
-    EXPECT_EQ(div, row.readFloat("d") / cvalue);
+    auto div = b3->eval<float>(ctx);
+    EXPECT_EQ(div, row.readFloat("d").value() / cvalue);
   }
 }
 
@@ -169,7 +155,7 @@ TEST(ValueEvalTest, TestValueEvalLogical) {
     EXPECT_CALL(row, readBool("flag")).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(row, readInt(testing::_)).WillRepeatedly(testing::Return(cvalue));
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(cvalue));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
+    EXPECT_CALL(row, readString(testing::_)).WillRepeatedly(testing::Return("abc"));
 
     EvalContext ctx{ false };
     ctx.reset(row);
@@ -178,19 +164,16 @@ TEST(ValueEvalTest, TestValueEvalLogical) {
     auto b3 = nebula::surface::eval::mul<float, int, float>(std::move(b1), std::move(b2));
     auto b4 = nebula::surface::eval::constant(32 * 33);
     auto b5 = nebula::surface::eval::gt<float, int>(std::move(b3), std::move(b4));
-    bool valid = true;
-    EXPECT_EQ(b5->eval<bool>(ctx, valid), false);
+    EXPECT_EQ(b5->eval<bool>(ctx).value(), false);
 
     auto b6 = nebula::surface::eval::constant(true);
     auto b7 = nebula::surface::eval::bor<bool, bool>(std::move(b5), std::move(b6));
     auto b8 = nebula::surface::eval::constant(true);
     auto b9 = nebula::surface::eval::eq<bool, bool>(std::move(b7), std::move(b8));
-    valid = true;
-    EXPECT_EQ(b9->eval<bool>(ctx, valid), true);
+    EXPECT_EQ(b9->eval<bool>(ctx).value(), true);
 
     auto b10 = nebula::surface::eval::column<std::string_view>("s");
-    valid = true;
-    LOG(INFO) << "b10=" << b10->eval<std::string_view>(ctx, valid);
+    LOG(INFO) << "b10=" << b10->eval<std::string_view>(ctx).value();
   }
 }
 
@@ -198,62 +181,51 @@ TEST(ValueEvalTest, TestStringValues) {
   MockRow row;
   const auto c = "abcdefg";
   EXPECT_CALL(row, readString(testing::_)).WillRepeatedly(testing::Return(c));
-  EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
   EvalContext ctx{ false };
   ctx.reset(row);
-  bool valid = true;
 
   {
     auto b1 = nebula::surface::eval::constant("abcdef");
-    auto v1 = b1->eval<std::string_view>(ctx, valid);
+    auto v1 = b1->eval<std::string_view>(ctx);
     EXPECT_EQ(v1, "abcdef");
 
-    valid = true;
     auto b2 = nebula::surface::eval::column<std::string_view>("x");
-    auto v2 = b2->eval<std::string_view>(ctx, valid);
+    auto v2 = b2->eval<std::string_view>(ctx);
     EXPECT_EQ(v2, c);
 
-    valid = true;
     auto b3 = eq<std::string_view, std::string_view>(std::move(b1), std::move(b2));
-    EXPECT_EQ(b3->eval<bool>(ctx, valid), false);
+    EXPECT_EQ(b3->eval<bool>(ctx), false);
   }
 
   {
-    valid = true;
     auto b1 = nebula::surface::eval::constant(c);
-    EXPECT_EQ(b1->eval<std::string_view>(ctx, valid), c);
+    EXPECT_EQ(b1->eval<std::string_view>(ctx), c);
 
-    valid = true;
     auto b2 = nebula::surface::eval::column<std::string_view>("x");
-    EXPECT_EQ(b2->eval<std::string_view>(ctx, valid), c);
+    EXPECT_EQ(b2->eval<std::string_view>(ctx), c);
 
-    valid = true;
     auto b3 = eq<std::string_view, std::string_view>(std::move(b1), std::move(b2));
-    EXPECT_EQ(b3->eval<bool>(ctx, valid), true);
+    EXPECT_EQ(b3->eval<bool>(ctx), true);
   }
 
   {
-    valid = true;
     auto b1 = nebula::surface::eval::constant("abc");
-    EXPECT_EQ(b1->eval<std::string_view>(ctx, valid), "abc");
+    EXPECT_EQ(b1->eval<std::string_view>(ctx), "abc");
 
-    valid = true;
     auto b2 = nebula::surface::eval::column<std::string_view>("x");
-    EXPECT_EQ(b2->eval<std::string_view>(ctx, valid), c);
+    EXPECT_EQ(b2->eval<std::string_view>(ctx), c);
 
-    valid = true;
     auto b3 = gt<std::string_view, std::string_view>(std::move(b2), std::move(b1));
-    EXPECT_EQ(b3->eval<bool>(ctx, valid), true);
+    EXPECT_EQ(b3->eval<bool>(ctx).value(), true);
   }
 
   {
     auto b1 = nebula::surface::eval::column<std::string_view>("x");
     auto b2 = nebula::surface::eval::column<std::string_view>("x");
 
-    valid = true;
     auto b3 = gt<std::string_view, std::string_view>(std::move(b1), std::move(b2));
-    EXPECT_EQ(b3->eval<bool>(ctx, valid), false);
+    EXPECT_EQ(b3->eval<bool>(ctx).value(), false);
   }
 }
 
@@ -268,17 +240,14 @@ TEST(ValueEvalTest, TestEvaluationContext) {
   {
     MockRow row;
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(1));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     // 1*2 < 3
     ctx.reset(row);
-    bool valid = true;
     // value cached by the same row, so no matter how many calls.
     // evaluate result should be the same
     LOG(INFO) << "signature of b5=" << b5->signature();
     for (auto i = 0; i < 1000; ++i) {
-      EXPECT_EQ(valid, true);
-      EXPECT_EQ(b5->eval<bool>(ctx, valid), false);
+      EXPECT_EQ(b5->eval<bool>(ctx), false);
     }
   }
 
@@ -286,14 +255,11 @@ TEST(ValueEvalTest, TestEvaluationContext) {
   {
     MockRow row;
     EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(2));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(false));
 
     // 2*2 > 3
-    bool valid = true;
     ctx.reset(row);
     for (auto i = 0; i < 1000; ++i) {
-      auto result = b5->eval<bool>(ctx, valid);
-      EXPECT_EQ(valid, true);
+      auto result = b5->eval<bool>(ctx);
       EXPECT_EQ(result, true);
     }
   }
@@ -301,18 +267,13 @@ TEST(ValueEvalTest, TestEvaluationContext) {
   // reset the row to context, it will get larger data since incrementation
   {
     MockRow row;
-    EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(2));
-    EXPECT_CALL(row, isNull(testing::_)).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(row, readFloat(testing::_)).WillRepeatedly(testing::Return(std::nullopt));
 
     // 2*2 > 3
     ctx.reset(row);
     for (auto i = 0; i < 1000; ++i) {
-      bool valid = true;
-      auto result = b5->eval<bool>(ctx, valid);
-      EXPECT_EQ(valid, false);
-      if (valid) {
-        EXPECT_EQ(result, true);
-      }
+      auto result = b5->eval<bool>(ctx);
+      EXPECT_EQ(result, std::nullopt);
     }
   }
 }

--- a/src/memory/Accessor.cpp
+++ b/src/memory/Accessor.cpp
@@ -43,11 +43,8 @@ RowAccessor& RowAccessor::seek(size_t rowId) {
   return *this;
 }
 
-bool RowAccessor::isNull(const std::string& field) const {
-  // check if field existing
-  const auto& itr = dnMap_.find(field);
-  N_ENSURE(itr != dnMap_.end(), fmt::format("field {0} not found!", field));
-  return itr->second->isNull(current_);
+inline bool RowAccessor::isNull(const std::string& field) const {
+  return dnMap_.at(field)->isNull(current_);
 }
 
 #define READ_TYPE_BY_FIELD(TYPE, FUNC)                                                        \

--- a/src/memory/Batch.h
+++ b/src/memory/Batch.h
@@ -177,26 +177,21 @@ private:
 using BatchPtr = std::shared_ptr<Batch>;
 using EvaledBlock = std::pair<Batch*, nebula::surface::eval::BlockEval>;
 
-class RowAccessor : public nebula::surface::RowData {
+class RowAccessor : public nebula::surface::Accessor {
 public:
   RowAccessor(const Batch& batch) : batch_{ batch }, dnMap_{ batch_.fields_ } {}
   virtual ~RowAccessor() = default;
 
 public:
-  bool isNull(const std::string& field) const override;
-  bool readBool(const std::string& field) const override;
-  int8_t readByte(const std::string& field) const override;
-  int16_t readShort(const std::string& field) const override;
-  int32_t readInt(const std::string& field) const override;
-  int64_t readLong(const std::string& field) const override;
-  float readFloat(const std::string& field) const override;
-  double readDouble(const std::string& field) const override;
-  int128_t readInt128(const std::string& field) const override;
-  std::string_view readString(const std::string& field) const override;
-
-  // compound types
-  std::unique_ptr<nebula::surface::ListData> readList(const std::string& field) const override;
-  std::unique_ptr<nebula::surface::MapData> readMap(const std::string& field) const override;
+  std::optional<bool> readBool(const std::string& field) const override;
+  std::optional<int8_t> readByte(const std::string& field) const override;
+  std::optional<int16_t> readShort(const std::string& field) const override;
+  std::optional<int32_t> readInt(const std::string& field) const override;
+  std::optional<int64_t> readLong(const std::string& field) const override;
+  std::optional<float> readFloat(const std::string& field) const override;
+  std::optional<double> readDouble(const std::string& field) const override;
+  std::optional<int128_t> readInt128(const std::string& field) const override;
+  std::optional<std::string_view> readString(const std::string& field) const override;
 
 public:
   RowAccessor& seek(size_t);

--- a/src/memory/keyed/FlatBuffer.h
+++ b/src/memory/keyed/FlatBuffer.h
@@ -179,7 +179,7 @@ public:
   }
 
 private:
-  bool appendNull(bool, nebula::type::Kind, Buffer&);
+  size_t appendNull(bool, nebula::type::Kind, Buffer&, size_t offset);
 
   template <typename T>
   size_t append(T, Buffer&, size_t = 0);

--- a/src/memory/serde/TypeData.h
+++ b/src/memory/serde/TypeData.h
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <glog/logging.h>
+
 #include "common/BloomFilter.h"
 #include "common/Likely.h"
 #include "common/Memory.h"
@@ -73,8 +74,8 @@ using StringData = TypeDataImpl<nebula::type::Kind::VARCHAR>;
 template <nebula::type::Kind KIND>
 class TypeDataImpl : public TypeData {
   using NType = typename nebula::type::TypeTraits<KIND>::CppType;
-  static constexpr auto Width = nebula::type::TypeTraits<KIND>::width;
   static constexpr auto Scalar = nebula::type::TypeBase::isScalar(KIND);
+  static constexpr auto Unit = Scalar ? nebula::type::TypeTraits<KIND>::width : 16;
 
 public:
   TypeDataImpl(const nebula::meta::Column&, size_t);
@@ -97,7 +98,7 @@ public:
   }
 
   NType read(IndexType index) const {
-    return slice_.template read<NType>(index * Width);
+    return slice_.template read<NType>(index * Unit);
   }
 
   inline std::string_view read(IndexType offset, IndexType size) {

--- a/src/meta/ClusterInfo.cpp
+++ b/src/meta/ClusterInfo.cpp
@@ -95,6 +95,10 @@ DataSource asDataSource(const std::string& data) {
     return DataSource::KAFKA;
   }
 
+  if (data == "local") {
+    return DataSource::LOCAL;
+  }
+
   throw NException("Misconfigured data source");
 }
 

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -37,8 +37,30 @@ namespace meta {
 enum class DataSource {
   Custom,
   S3,
+  LOCAL,
   KAFKA,
   GSHEET
+};
+
+struct DataSourceUtils {
+  static bool isFileSystem(const DataSource& ds) {
+    return ds == DataSource::S3 || ds == DataSource::LOCAL;
+  }
+
+  static const std::string& getProtocol(const DataSource& ds) {
+    static const std::string NONE = "";
+    static const nebula::common::unordered_map<DataSource, std::string> SOURCE_PROTO = {
+      { DataSource::S3, "s3" },
+      { DataSource::LOCAL, "local" }
+    };
+
+    auto p = SOURCE_PROTO.find(ds);
+    if (p != SOURCE_PROTO.end()) {
+      return p->second;
+    }
+
+    return NONE;
+  }
 };
 
 // type of time source to fill time column

--- a/src/storage/CsvReader.h
+++ b/src/storage/CsvReader.h
@@ -151,7 +151,9 @@ public:
     // TODO(cao) - current CSV reading implementation ignores escape special chars case
     // we should handle those to skip less rows
     while (fstream_ >> row_) {
-      if (row_.rawData().size() == columns_.size()) {
+      // sometimes the data has trailing delimeter
+      // and we may have one more collected than column size
+      if (row_.rawData().size() >= columns_.size()) {
         size_ += 1;
         break;
       }

--- a/src/storage/NFS.cpp
+++ b/src/storage/NFS.cpp
@@ -56,7 +56,11 @@ UriInfo parse(const std::string& strUri) {
     info.host = UF_STR(hostText);
   }
 
-  if (uri.pathHead) {
+  // TODO(cao) - doesn't seem system compatible? probably remove
+  // handle local path without starting '/'
+  if (info.schema.empty() && info.host.empty() && strUri.at(0) != '/') {
+    info.path = fmt::format("/{0}", strUri);
+  } else if (uri.pathHead) {
     const UriPathSegmentA* p = uri.pathHead;
     const char* start = p->text.first;
     const char* end = nullptr;
@@ -69,7 +73,12 @@ UriInfo parse(const std::string& strUri) {
       }
     }
 
-    // we know it's from the same string.
+    // if schema is empty, assume it's a local file.
+    // allow it to carry the char before it.
+    if (info.schema.empty() || info.host.empty()) {
+      start -= 1;
+    }
+
     info.path = std::string(start, end - start);
 
     // decode the data in place, and mark end position to be 0

--- a/src/storage/local/File.h
+++ b/src/storage/local/File.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
-#include <dirent.h>
+#include <filesystem>
 #include <string>
 #include <vector>
+
 #include "common/Errors.h"
 #include "storage/NFileSystem.h"
 
@@ -43,8 +44,10 @@ public:
   // return file info of given file path
   virtual FileInfo info(const std::string&) override;
 
-  virtual bool copy(const std::string&, const std::string&) override {
-    throw NException("Not implemented");
+  virtual inline bool copy(const std::string& from, const std::string& to) override {
+    // TODO(cao): it doesn't copy anything if options specified (e.g replace_existing)
+    std::filesystem::copy(from, to, std::filesystem::copy_options::overwrite_existing);
+    return true;
   }
 
   virtual std::string temp(bool = false) override;

--- a/src/surface/DataSurface.h
+++ b/src/surface/DataSurface.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string_view>
 
 #include "common/Cursor.h"
@@ -163,6 +164,21 @@ public:
 
 private:
   IndexType items_;
+};
+
+// for low level data access - avoid row data interface for possible optimization
+class Accessor {
+public:
+  virtual ~Accessor() = default;
+  virtual std::optional<bool> readBool(const std::string&) const = 0;
+  virtual std::optional<int8_t> readByte(const std::string&) const = 0;
+  virtual std::optional<int16_t> readShort(const std::string&) const = 0;
+  virtual std::optional<int32_t> readInt(const std::string&) const = 0;
+  virtual std::optional<int64_t> readLong(const std::string&) const = 0;
+  virtual std::optional<float> readFloat(const std::string&) const = 0;
+  virtual std::optional<double> readDouble(const std::string&) const = 0;
+  virtual std::optional<int128_t> readInt128(const std::string&) const = 0;
+  virtual std::optional<std::string_view> readString(const std::string&) const = 0;
 };
 
 } // namespace surface

--- a/src/surface/MockSurface.cpp
+++ b/src/surface/MockSurface.cpp
@@ -185,5 +185,43 @@ std::unique_ptr<ListData> MockMapData::readValues() const {
   return std::make_unique<MockListData>(getItems());
 }
 
+///////////////////////////////////////////////////////////
+std::optional<bool> MockAccessor::readBool(const std::string&) const {
+  // half of trues
+  return rand_() < 0.5;
+}
+
+std::optional<int8_t> MockAccessor::readByte(const std::string&) const {
+  return std::numeric_limits<int8_t>::max() * rand_();
+}
+
+std::optional<int16_t> MockAccessor::readShort(const std::string&) const {
+  return std::numeric_limits<int16_t>::max() * rand_();
+}
+
+std::optional<int32_t> MockAccessor::readInt(const std::string&) const {
+  return std::numeric_limits<int32_t>::max() * rand_();
+}
+
+std::optional<int64_t> MockAccessor::readLong(const std::string&) const {
+  return std::numeric_limits<int64_t>::max() * rand_();
+}
+
+std::optional<float> MockAccessor::readFloat(const std::string&) const {
+  return rand_();
+}
+
+std::optional<double> MockAccessor::readDouble(const std::string&) const {
+  return rand_();
+}
+
+std::optional<int128_t> MockAccessor::readInt128(const std::string&) const {
+  return std::numeric_limits<int128_t>::max() * rand_();
+}
+
+std::optional<std::string_view> MockAccessor::readString(const std::string&) const {
+  return strings_.at(rand_() * strings_.size());
+}
+
 } // namespace surface
 } // namespace nebula

--- a/src/surface/MockSurface.h
+++ b/src/surface/MockSurface.h
@@ -27,7 +27,7 @@ class MockData {
 public:
   MockData(size_t seed = 0)
     : rand_{ nebula::common::Evidence::rand(
-        seed == 0 ? nebula::common::Evidence::ticks() : seed) } {}
+      seed == 0 ? nebula::common::Evidence::ticks() : seed) } {}
   virtual ~MockData() = default;
 
 protected:
@@ -126,6 +126,31 @@ public:
   MockMapData(IndexType items, size_t seed = 0) : MapData(items), MockData(seed) {}
   std::unique_ptr<ListData> readKeys() const override;
   std::unique_ptr<ListData> readValues() const override;
+};
+
+// Supported compound types
+class MockAccessor : public Accessor, protected MockData {
+public:
+  MockAccessor(size_t seed = 0) : MockData(seed) {
+    strings_.reserve(32);
+    for (auto i = 0; i < 32; ++i) {
+      strings_.push_back(std::string(rand_() * 10, 'N'));
+    }
+  }
+
+public:
+  virtual std::optional<bool> readBool(const std::string& field) const override;
+  virtual std::optional<int8_t> readByte(const std::string& field) const override;
+  virtual std::optional<int16_t> readShort(const std::string& field) const override;
+  virtual std::optional<int32_t> readInt(const std::string& field) const override;
+  virtual std::optional<int64_t> readLong(const std::string& field) const override;
+  virtual std::optional<float> readFloat(const std::string& field) const override;
+  virtual std::optional<double> readDouble(const std::string& field) const override;
+  virtual std::optional<int128_t> readInt128(const std::string& field) const override;
+  virtual std::optional<std::string_view> readString(const std::string& field) const override;
+
+private:
+  std::vector<std::string> strings_;
 };
 
 } // namespace surface

--- a/src/surface/eval/EvalContext.cpp
+++ b/src/surface/eval/EvalContext.cpp
@@ -27,7 +27,7 @@ namespace surface {
 namespace eval {
 
 // reset to a new row
-void EvalContext::reset(const nebula::surface::RowData& row) {
+void EvalContext::reset(const nebula::surface::Accessor& row) {
   // std::addressof ?
   this->row_ = &row;
 

--- a/src/surface/eval/EvalContext.h
+++ b/src/surface/eval/EvalContext.h
@@ -86,7 +86,7 @@ public:
   // 2. std::optinal<T> to return optional value.
   // 3. a flag to indicate the return value should not be used
   template <typename T>
-  inline T eval(EvalContext& ctx, bool& valid) const {
+  inline std::optional<T> eval(EvalContext& ctx) const {
     // TODO(cao) - there is a problem wasted me a WHOLE day to figure out the root cause.
     // So document here for further robust engineering work, the case is like this:
     // When it create ValueEval, it uses template to generate TypeValueEval<std::string> for VARCHAR type
@@ -98,7 +98,7 @@ public:
     // N_ENSURE_NOT_NULL(p, "type should match");
     auto p = static_cast<const TypeValueEval<T>*>(this);
     // N_ENSURE_NOT_NULL(p, "Type should match in value eval!");
-    return p->eval(ctx, valid);
+    return p->eval(ctx);
   }
 
   // stack value into object
@@ -149,10 +149,10 @@ protected:
 // customized functions defined by each individual typed value eval object
 #define EvalBlock std::function<BlockEval(const Block&)>
 #define SketchMaker std::function<std::shared_ptr<Aggregator<OutputTD::kind, InputTD::kind>>()>
-#define OPT std::function<EvalType(EvalContext&, const std::vector<std::unique_ptr<ValueEval>>&, bool&)>
-#define OPT_LAMBDA(X)                                                                           \
-  ([](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>& children, bool& valid) { \
-    X                                                                                           \
+#define OPT std::function<std::optional<EvalType>(EvalContext&, const std::vector<std::unique_ptr<ValueEval>>&)>
+#define OPT_LAMBDA(T, X)                                                                               \
+  ([](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>& children) -> std::optional<T> { \
+    X                                                                                                  \
   })
 
 // TODO(cao): evaluate if we can template TypeValueEval with nebula::type::Kind
@@ -183,8 +183,8 @@ public:
 
   virtual ~TypeValueEval() = default;
 
-  inline EvalType eval(EvalContext& ctx, bool& valid) const {
-    return op_(ctx, this->children_, valid);
+  inline std::optional<EvalType> eval(EvalContext& ctx) const {
+    return op_(ctx, this->children_);
   }
 
   inline std::shared_ptr<Aggregator<OutputTD::kind, InputTD::kind>> sketch() const {
@@ -270,76 +270,65 @@ public:
     : EvalContext(cache, script, nullptr) {}
 
   // case to wrap a single row without cache, cheap to create an instance of eval context
-  EvalContext(std::unique_ptr<nebula::surface::RowData> data, std::shared_ptr<ScriptData> script = nullptr)
+  EvalContext(std::unique_ptr<nebula::surface::Accessor> data, std::shared_ptr<ScriptData> script = nullptr)
     : EvalContext(false, script, std::move(data)) {}
 
   virtual ~EvalContext() = default;
 
   // change reference to row data, clear all cache.
   // and start build cache based on evaluation signautre.
-  void reset(const nebula::surface::RowData&);
-
-#define NULL_CHECK(R)                \
-  if (UNLIKELY(row_->isNull(col))) { \
-    valid = false;                   \
-    return R;                        \
-  }
+  void reset(const nebula::surface::Accessor&);
 
   template <typename T>
-  inline T read(const std::string& col, bool& valid) {
+  inline std::optional<T> read(const std::string& col) {
     // TODO(cao) - not ideal branching. we should be able to compile this before execution
     // fast lookup - best to turn all column's value materialization into a function pointer - type agnostic?
     // we exactly know what method to call for every single column
-    ValueEval* ve = nullptr;
-    if (scriptData_ && (ve = scriptData_->column(col)) != nullptr) {
-      return ve->eval<T>(*this, valid);
+
+    // perf: we pay this check for every read
+    if (UNLIKELY(scriptData_ != nullptr)) {
+      ValueEval* ve = scriptData_->column(col);
+      if (ve) {
+        return ve->eval<T>(*this);
+      }
     }
 
     // return *row_;
     // compile time branching based on template type T
     // I think it's better than using template specialization for this case
     if constexpr (std::is_same<T, bool>::value) {
-      NULL_CHECK(false)
       return row_->readBool(col);
     }
 
     if constexpr (std::is_same<T, int8_t>::value) {
-      NULL_CHECK(0)
       return row_->readByte(col);
     }
 
     if constexpr (std::is_same<T, int16_t>::value) {
-      NULL_CHECK(0)
       return row_->readShort(col);
     }
 
     if constexpr (std::is_same<T, int32_t>::value) {
-      NULL_CHECK(0)
       return row_->readInt(col);
     }
 
     if constexpr (std::is_same<T, int64_t>::value) {
-      NULL_CHECK(0)
       return row_->readLong(col);
     }
 
     if constexpr (std::is_same<T, float>::value) {
-      NULL_CHECK(0)
       return row_->readFloat(col);
     }
 
     if constexpr (std::is_same<T, double>::value) {
-      NULL_CHECK(0)
       return row_->readDouble(col);
     }
 
     if constexpr (std::is_same<T, int128_t>::value) {
-      NULL_CHECK(0)
       return row_->readInt128(col);
     }
 
     if constexpr (std::is_same<T, std::string_view>::value) {
-      NULL_CHECK("")
       return row_->readString(col);
     }
 
@@ -356,12 +345,12 @@ public:
 private:
   EvalContext(bool cache,
               std::shared_ptr<ScriptData> scriptData,
-              std::unique_ptr<nebula::surface::RowData> data)
+              std::unique_ptr<nebula::surface::Accessor> data)
     : cache_{ !cache ? nullptr : std::make_unique<EvalCache>(1024) },
       scriptData_{ scriptData },
       script_{ scriptData == nullptr ? nullptr :
                                        std::make_unique<ScriptContext>(
-                                         [this]() -> const nebula::surface::RowData& { return *row_; },
+                                         [this]() -> const nebula::surface::Accessor& { return *row_; },
                                          [this](const std::string& col) -> auto {
                                            return scriptData_->name2type->at(col);
                                          }) },
@@ -378,10 +367,10 @@ private:
   std::unique_ptr<ScriptContext> script_;
 
   // the context may own a row object directly
-  std::unique_ptr<nebula::surface::RowData> data_;
+  std::unique_ptr<nebula::surface::Accessor> data_;
 
   // row object pointer
-  const nebula::surface::RowData* row_;
+  const nebula::surface::Accessor* row_;
 };
 
 } // namespace eval

--- a/src/surface/eval/UDF.h
+++ b/src/surface/eval/UDF.h
@@ -52,16 +52,16 @@ class UDF : public BaseType {
 public:
   using NativeType = typename nebula::type::TypeTraits<NK>::CppType;
   using InputType = typename nebula::type::TypeTraits<IK>::CppType;
-  using Logic = std::function<NativeType(const InputType&, bool& valid)>;
+  using Logic = std::function<NativeType(const std::optional<InputType>&)>;
   using EvalBlock = std::function<BlockEval(const Block&)>;
 
   UDF(const std::string& name, std::unique_ptr<nebula::surface::eval::ValueEval> expr, Logic&& logic, EvalBlock&& eb = uncertain)
     : BaseType(
       fmt::format("{0}({1})", name, expr->signature()),
       ExpressionType::FUNCTION,
-      [this](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>&, bool& valid) -> decltype(auto) {
+      [this](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>&) -> decltype(auto) {
         // call the UDF to evalue the result
-        return logic_(expr_->eval<InputType>(ctx, valid), valid);
+        return logic_(expr_->eval<InputType>(ctx));
       },
       std::move(eb)),
       expr_{ std::move(expr) },
@@ -98,9 +98,9 @@ public:
     : BaseType(
       fmt::format("{0}({1})", name, expr->signature()),
       ExpressionType::FUNCTION,
-      [this](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>&, bool& valid) -> decltype(auto) {
+      [this](EvalContext& ctx, const std::vector<std::unique_ptr<ValueEval>>&) -> decltype(auto) {
         // call the UDF to evalue the result
-        return expr_->eval<InputType>(ctx, valid);
+        return expr_->eval<InputType>(ctx);
       },
       uncertain,
       std::move(maker),

--- a/src/surface/eval/UDF.h
+++ b/src/surface/eval/UDF.h
@@ -52,10 +52,13 @@ class UDF : public BaseType {
 public:
   using NativeType = typename nebula::type::TypeTraits<NK>::CppType;
   using InputType = typename nebula::type::TypeTraits<IK>::CppType;
-  using Logic = std::function<NativeType(const std::optional<InputType>&)>;
+  using Logic = std::function<std::optional<NativeType>(const std::optional<InputType>&)>;
   using EvalBlock = std::function<BlockEval(const Block&)>;
 
-  UDF(const std::string& name, std::unique_ptr<nebula::surface::eval::ValueEval> expr, Logic&& logic, EvalBlock&& eb = uncertain)
+  UDF(const std::string& name,
+      std::unique_ptr<nebula::surface::eval::ValueEval> expr,
+      Logic&& logic,
+      EvalBlock&& eb = uncertain)
     : BaseType(
       fmt::format("{0}({1})", name, expr->signature()),
       ExpressionType::FUNCTION,
@@ -121,6 +124,7 @@ enum class UDFType {
   LIKE,
   PREFIX,
   IN,
+  BETWEEN,
   // UDAF
   MAX,
   MIN,
@@ -203,6 +207,20 @@ UDF_TRAITS(PREFIX, nebula::type::Kind::BOOLEAN, nebula::type::Kind::VARCHAR)
 // IN function looks for expected value in given list of values
 STATIC_TRAITS(IN, false)
 REPEAT_ALL_TYPES(UDF_TRAITS_INPUT1, IN, nebula::type::Kind::BOOLEAN)
+
+// define traits for UDF: between
+// BETWEEN function looks for if evaluated value is in a given range
+STATIC_TRAITS(BETWEEN, false)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::TINYINT)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::SMALLINT)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::INTEGER)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::BIGINT)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::REAL)
+UDF_TRAITS(BETWEEN, nebula::type::Kind::BOOLEAN, nebula::type::Kind::DOUBLE)
+UDF_NOT_SUPPORT(BETWEEN, nebula::type::Kind::INVALID)
+UDF_NOT_SUPPORT(BETWEEN, nebula::type::Kind::BOOLEAN)
+UDF_NOT_SUPPORT(BETWEEN, nebula::type::Kind::VARCHAR)
+UDF_NOT_SUPPORT(BETWEEN, nebula::type::Kind::INT128)
 
 // define each UDAF type taits
 // define traits for UDAF: MAX

--- a/src/surface/eval/ValueEval.cpp
+++ b/src/surface/eval/ValueEval.cpp
@@ -37,7 +37,7 @@ using nebula::type::TypeTraits;
 // if the column is partition column, we use partition values, otherwise use histogram
 #define MIN_MAX_COMPARE(KIND, HT, NONE_EXP, ALL_EXP)        \
   using ET = TypeTraits<Kind::KIND>::CppType;               \
-  auto value = c->eval<ET>(ctx, valid);                     \
+  auto value = c->eval<ET>(ctx);                            \
   auto min = std::numeric_limits<ET>::max();                \
   auto max = std::numeric_limits<ET>::min();                \
   auto values = b.partitionValues(name);                    \
@@ -74,7 +74,6 @@ EvalBlock buildEvalBlock<LogicalOp::GT>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {
@@ -112,7 +111,6 @@ EvalBlock buildEvalBlock<LogicalOp::GE>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {
@@ -150,7 +148,6 @@ EvalBlock buildEvalBlock<LogicalOp::LT>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {
@@ -188,7 +185,6 @@ EvalBlock buildEvalBlock<LogicalOp::LE>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {
@@ -233,7 +229,7 @@ EvalBlock buildEvalBlock<LogicalOp::LE>(const std::unique_ptr<ValueEval>& left,
   using CT = std::conditional_t<Kind::KIND == Kind::VARCHAR, std::string, ET>; \
   auto A = NOT ? BlockEval::NONE : BlockEval::ALL;                             \
   auto N = NOT ? BlockEval::ALL : BlockEval::NONE;                             \
-  auto value = c->eval<ET>(ctx, valid);                                        \
+  auto value = c->eval<ET>(ctx);                                               \
   auto values = b.partitionValues(name);                                       \
   if (values.size() > 0) {                                                     \
     for (auto v : values) {                                                    \
@@ -244,7 +240,7 @@ EvalBlock buildEvalBlock<LogicalOp::LE>(const std::unique_ptr<ValueEval>& left,
     }                                                                          \
     return N;                                                                  \
   }                                                                            \
-  if (!b.probably(name, value)) {                                              \
+  if (value != std::nullopt && !b.probably(name, value.value())) {             \
     return N;                                                                  \
   }
 
@@ -266,7 +262,6 @@ EvalBlock buildEvalBlock<LogicalOp::EQ>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {
@@ -302,7 +297,6 @@ EvalBlock buildEvalBlock<LogicalOp::NEQ>(const std::unique_ptr<ValueEval>& left,
     std::string colName(left->signature().substr(2));
     return [name = std::move(colName), c = right.get()](const Block& b) -> BlockEval {
       EvalContext ctx{ false };
-      bool valid;
       // logic
       auto ct = b.columnType(name);
       switch (ct->k()) {

--- a/src/surface/eval/ValueEval.h
+++ b/src/surface/eval/ValueEval.h
@@ -120,11 +120,11 @@ std::unique_ptr<ValueEval> custom(const std::string& name, const std::string& ex
         fmt::format("({0}{1}{2})", s1, #SIGN, s2),                                                \
         ExpressionType::ARTHMETIC,                                                                \
         OPT_LAMBDA({                                                                              \
-          auto v1 = ctx.eval<T1>(*children[0], valid);                                            \
+          auto v1 = children.at(0)->eval<T1>(ctx, valid);                                         \
           if (UNLIKELY(!valid)) {                                                                 \
             return INVALID;                                                                       \
           }                                                                                       \
-          auto v2 = ctx.eval<T2>(*children[1], valid);                                            \
+          auto v2 = children.at(1)->eval<T2>(ctx, valid);                                         \
           if (UNLIKELY(!valid)) {                                                                 \
             return INVALID;                                                                       \
           }                                                                                       \
@@ -182,11 +182,11 @@ BEB_LOGICAL(OR)
         fmt::format("({0}{1}{2})", s1, #SIGN, s2),                                                \
         ExpressionType::LOGICAL,                                                                  \
         OPT_LAMBDA({                                                                              \
-          auto v1 = ctx.eval<T1>(*children.at(0), valid);                                         \
+          auto v1 = children.at(0)->eval<T1>(ctx, valid);                                         \
           if (UNLIKELY(!valid)) {                                                                 \
             return false;                                                                         \
           }                                                                                       \
-          auto v2 = ctx.eval<T2>(*children.at(1), valid);                                         \
+          auto v2 = children.at(1)->eval<T2>(ctx, valid);                                         \
           if (UNLIKELY(!valid)) {                                                                 \
             return false;                                                                         \
           }                                                                                       \

--- a/src/surface/eval/ValueEval.h
+++ b/src/surface/eval/ValueEval.h
@@ -92,7 +92,7 @@ std::unique_ptr<ValueEval> custom(const std::string& name, const std::string& ex
 
         // only continue if current expression evaluated correctly
         // next let's invote it ot get the value we want
-        if (decl) {
+        if (decl && decl.value()) {
           return ctx.script().eval<T>(fmt::format("{0}();", name));
         }
 

--- a/src/surface/test/TestSurface.cpp
+++ b/src/surface/test/TestSurface.cpp
@@ -82,9 +82,10 @@ TEST(SurfaceTest, TestScriptContext) {
   const auto seed = Evidence::unix_timestamp();
   nebula::surface::MockRowData mock1(seed);
   nebula::surface::MockRowData mock2(seed);
+  nebula::surface::MockAccessor mockA(seed);
   nebula::surface::eval::ScriptContext script(
-    [&mock1]() -> const nebula::surface::RowData& {
-      return mock1;
+    [&mockA]() -> const nebula::surface::Accessor& {
+      return mockA;
     },
     [](const std::string& col) -> auto {
       if (col == "c") {
@@ -101,18 +102,15 @@ TEST(SurfaceTest, TestScriptContext) {
   // int 32 value overflow:
   // C++: (1896463358 * 2 - 2147483648-2147483648)
   // JS: ??
-  bool valid;
-  script.eval<int32_t>("var x = () => nebula.column('c') - 100;", valid);
-  script.eval<bool>("var y = () => nebula.column('str').length;", valid);
+  script.eval<int32_t>("var x = () => nebula.column('c') - 100;");
+  script.eval<bool>("var y = () => nebula.column('str').length;");
   for (auto i = 0; i < 16; ++i) {
-    auto x = script.eval<int32_t>("x();", valid);
+    auto x = script.eval<int32_t>("x();");
     auto col_c = mock2.readInt("c");
-    EXPECT_TRUE(valid);
     EXPECT_EQ(x, col_c - 100);
 
-    auto y = script.eval<int32_t>("y();", valid);
+    auto y = script.eval<int32_t>("y();");
     auto col_str = mock2.readString("str");
-    EXPECT_TRUE(valid);
     EXPECT_EQ(y, col_str.size());
   }
 }


### PR DESCRIPTION
Use TPC-H lineitem data set to make a bench run.
Current benchmark is test driven by "Run a few different queries over 1GB or 6M rows of line item data set on a single CPU core". 

This change set is mostly code path optimizations. The result of this PR is to bring one of the benchmark test from `3.5s` to `1.2s` one a single CPU for full 6M aggregations on 4 fields with a pattern match.

Expect vectorization on many operators will bring lots of gain which is a big change will defer to another PR.