### PR TITLE
make pattern string and path {macro} case insensitive during spec gen

### DIFF
--- a/src/configs/cluster.yml
+++ b/src/configs/cluster.yml
@@ -28,7 +28,7 @@ server:
   discovery:
     method: service
 
-# will be provided by enviroment
+# will be provided by environment
 nodes:
   - node:
       host: localhost

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -64,12 +64,12 @@ tables:
         dict: true
     time:
       type: macro
-      pattern: date
+      pattern: daily
 
   nebula.hourly:
     # size and time may not be respected - ephemeral
     max-mb: 10000
-    max-hr: 1
+    max-hr: 4
     schema: "ROW<actor_id:string, pin_id:bigint, partner_id:bigint, ct:bigint, app:string, domain:string, url:string, image_signature:string, root_pin_id:bigint, is_video:boolean, board_id:bigint, publish_type:int, create_date_ts:bigint, country:string, metro:int, gender:tinyint, age:smallint, custom_tag:int>"
     data: s3
     loader: Api
@@ -90,5 +90,5 @@ tables:
         dict: true
     time:
       type: macro
-      # support granularity between DATE to DATE HOUR MINUTE SECOND
-      pattern: date HOUR
+      # support granularity between DAILY, HOURLY, MINUTELY, SECONDLY
+      pattern: HOURLY

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -91,4 +91,4 @@ tables:
     time:
       type: macro
       # support granularity between DATE to DATE HOUR MINUTE SECOND
-      pattern: date hour
+      pattern: date HOUR

--- a/src/ingest/test/TestIngestion.cpp
+++ b/src/ingest/test/TestIngestion.cpp
@@ -91,7 +91,7 @@ TEST(IngestTest, TestTableSpec) {
     const auto name = spec->name;
     if (type == meta::TimeType::MACRO && name == "nebula.hourly") {
       meta::PatternMacro marco = meta::extractPatternMacro(spec->timeSpec.pattern);
-      EXPECT_EQ(spec->timeSpec.pattern, "date hour");
+      EXPECT_EQ(spec->timeSpec.pattern, "date HOUR");
       EXPECT_EQ(marco, meta::PatternMacro::HOUR);
 
       const auto sourceInfo = nebula::storage::parse(spec->location);

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -81,13 +81,13 @@ enum class TimeType {
 // type of macros accepted in table spec
 enum class PatternMacro {
   // Daily partition /dt=?
-  DATE,
+  DAILY,
   // hourly partition name /dt=?/hr=?
-  HOUR,
+  HOURLY,
   // minute partition name /dt=?/hr=?/mi=?
-  MINUTE,
+  MINUTELY,
   // use second level directory name /dt=?/hr=?/mi=?/se=?
-  SECOND,
+  SECONDLY,
   // use directory name in unix timestamp /ts=?
   TIMESTAMP,
   // placeholder for not accepted marcos
@@ -229,30 +229,39 @@ constexpr auto DAY_HOURS = 24;
 constexpr auto HOUR_SECONDS = HOUR_MINUTES * MINUTE_SECONDS;
 constexpr auto DAY_SECONDS = HOUR_SECONDS * DAY_HOURS;
 
-const nebula::common::unordered_map<nebula::meta::PatternMacro, std::string> patternYMLStr{
-  { nebula::meta::PatternMacro::DATE, "date" },
-  { nebula::meta::PatternMacro::HOUR, "hour" },
-  { nebula::meta::PatternMacro::MINUTE, "minute" },
-  { nebula::meta::PatternMacro::SECOND, "second" },
+const nebula::common::unordered_map<nebula::meta::PatternMacro, std::string> patternDefinitionStr{
+  { nebula::meta::PatternMacro::DAILY, "daily" },
+  { nebula::meta::PatternMacro::HOURLY, "hourly" },
+  { nebula::meta::PatternMacro::MINUTELY, "minutely" },
+  { nebula::meta::PatternMacro::SECONDLY, "secondly" },
+  { nebula::meta::PatternMacro::TIMESTAMP, "timestamp" }
+};
+
+// match fs location macro e.g {date}
+const nebula::common::unordered_map<nebula::meta::PatternMacro, std::string> patternMacroStr{
+  { nebula::meta::PatternMacro::DAILY, "date" },
+  { nebula::meta::PatternMacro::HOURLY, "hour" },
+  { nebula::meta::PatternMacro::MINUTELY, "minute" },
+  { nebula::meta::PatternMacro::SECONDLY, "second" },
   { nebula::meta::PatternMacro::TIMESTAMP, "timestamp" }
 };
 
 const nebula::common::unordered_map<nebula::meta::PatternMacro, nebula::meta::PatternMacro> childPattern{
-  { nebula::meta::PatternMacro::DATE, nebula::meta::PatternMacro::HOUR },
-  { nebula::meta::PatternMacro::HOUR, nebula::meta::PatternMacro::MINUTE },
-  { nebula::meta::PatternMacro::MINUTE, nebula::meta::PatternMacro::SECOND }
+  { nebula::meta::PatternMacro::DAILY, nebula::meta::PatternMacro::HOURLY },
+  { nebula::meta::PatternMacro::HOURLY, nebula::meta::PatternMacro::MINUTELY },
+  { nebula::meta::PatternMacro::MINUTELY, nebula::meta::PatternMacro::SECONDLY }
 };
 
 const nebula::common::unordered_map<nebula::meta::PatternMacro, int> unitInSeconds{
-  { nebula::meta::PatternMacro::DATE, DAY_SECONDS },
-  { nebula::meta::PatternMacro::HOUR, HOUR_SECONDS },
-  { nebula::meta::PatternMacro::MINUTE, MINUTE_SECONDS }
+  { nebula::meta::PatternMacro::DAILY, DAY_SECONDS },
+  { nebula::meta::PatternMacro::HOURLY, HOUR_SECONDS },
+  { nebula::meta::PatternMacro::MINUTELY, MINUTE_SECONDS }
 };
 
 const nebula::common::unordered_map<nebula::meta::PatternMacro, int> childSize{
-  { nebula::meta::PatternMacro::DATE, DAY_HOURS },
-  { nebula::meta::PatternMacro::HOUR, HOUR_MINUTES },
-  { nebula::meta::PatternMacro::MINUTE, MINUTE_SECONDS }
+  { nebula::meta::PatternMacro::DAILY, DAY_HOURS },
+  { nebula::meta::PatternMacro::HOURLY, HOUR_MINUTES },
+  { nebula::meta::PatternMacro::MINUTELY, MINUTE_SECONDS }
 };
 
 // check if pattern string type
@@ -261,20 +270,20 @@ inline nebula::meta::PatternMacro extractPatternMacro(const std::string& pattern
   std::string lpattern;
   transform(pattern.begin(), pattern.end(), std::back_inserter(lpattern), tolower);
 
-  const auto tsMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::TIMESTAMP)) != std::string::npos;
-  const auto dateMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::DATE)) != std::string::npos;
-  const auto hourMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::HOUR)) != std::string::npos;
-  const auto minuteMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::MINUTE)) != std::string::npos;
-  const auto secondMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::SECOND)) != std::string::npos;
+  const auto tsMacroFound = lpattern.find(patternDefinitionStr.at(PatternMacro::TIMESTAMP)) != std::string::npos;
+  const auto dateMacroFound = lpattern.find(patternDefinitionStr.at(PatternMacro::DAILY)) != std::string::npos;
+  const auto hourMacroFound = lpattern.find(patternDefinitionStr.at(PatternMacro::HOURLY)) != std::string::npos;
+  const auto minuteMacroFound = lpattern.find(patternDefinitionStr.at(PatternMacro::MINUTELY)) != std::string::npos;
+  const auto secondMacroFound = lpattern.find(patternDefinitionStr.at(PatternMacro::SECONDLY)) != std::string::npos;
 
-  if (secondMacroFound && minuteMacroFound && hourMacroFound && dateMacroFound) {
-    return PatternMacro::SECOND;
-  } else if (minuteMacroFound && hourMacroFound && dateMacroFound) {
-    return PatternMacro::MINUTE;
-  } else if (hourMacroFound && dateMacroFound && !secondMacroFound) {
-    return PatternMacro::HOUR;
+  if (secondMacroFound) {
+    return PatternMacro::SECONDLY;
+  } else if (minuteMacroFound) {
+    return PatternMacro::MINUTELY;
+  } else if (hourMacroFound) {
+    return PatternMacro::HOURLY;
   } else if (dateMacroFound && !minuteMacroFound && !secondMacroFound) {
-    return PatternMacro::DATE;
+    return PatternMacro::DAILY;
   }
 
   if (tsMacroFound && !secondMacroFound && !minuteMacroFound && !hourMacroFound && !dateMacroFound) {

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -257,11 +257,15 @@ const nebula::common::unordered_map<nebula::meta::PatternMacro, int> childSize{
 
 // check if pattern string type
 inline nebula::meta::PatternMacro extractPatternMacro(const std::string& pattern) {
-  const auto tsMacroFound = pattern.find(patternYMLStr.at(PatternMacro::TIMESTAMP)) != std::string::npos;
-  const auto dateMacroFound = pattern.find(patternYMLStr.at(PatternMacro::DATE)) != std::string::npos;
-  const auto hourMacroFound = pattern.find(patternYMLStr.at(PatternMacro::HOUR)) != std::string::npos;
-  const auto minuteMacroFound = pattern.find(patternYMLStr.at(PatternMacro::MINUTE)) != std::string::npos;
-  const auto secondMacroFound = pattern.find(patternYMLStr.at(PatternMacro::SECOND)) != std::string::npos;
+  // lowercase pattern string match
+  std::string lpattern;
+  transform(pattern.begin(), pattern.end(), std::back_inserter(lpattern), tolower);
+
+  const auto tsMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::TIMESTAMP)) != std::string::npos;
+  const auto dateMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::DATE)) != std::string::npos;
+  const auto hourMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::HOUR)) != std::string::npos;
+  const auto minuteMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::MINUTE)) != std::string::npos;
+  const auto secondMacroFound = lpattern.find(patternYMLStr.at(PatternMacro::SECOND)) != std::string::npos;
 
   if (secondMacroFound && minuteMacroFound && hourMacroFound && dateMacroFound) {
     return PatternMacro::SECOND;

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -282,7 +282,7 @@ inline nebula::meta::PatternMacro extractPatternMacro(const std::string& pattern
     return PatternMacro::MINUTELY;
   } else if (hourMacroFound) {
     return PatternMacro::HOURLY;
-  } else if (dateMacroFound && !minuteMacroFound && !secondMacroFound) {
+  } else if (dateMacroFound) {
     return PatternMacro::DAILY;
   }
 

--- a/src/meta/test/TestTableSpec.cpp
+++ b/src/meta/test/TestTableSpec.cpp
@@ -28,21 +28,19 @@ namespace test {
  * Test extract pattern marco from table spec configuration
  */
 TEST(MetaTest, TestExtractPatternMacro) {
-  EXPECT_EQ(nebula::meta::extractPatternMacro("date"), nebula::meta::PatternMacro::DATE);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("daily"), nebula::meta::PatternMacro::DAILY);
 
-  EXPECT_EQ(nebula::meta::extractPatternMacro("date hour"), nebula::meta::PatternMacro::HOUR);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("HOURLY"), nebula::meta::PatternMacro::HOURLY);
 
-  EXPECT_EQ(nebula::meta::extractPatternMacro("hour date"), nebula::meta::PatternMacro::HOUR);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("Hourly"), nebula::meta::PatternMacro::HOURLY);
 
-  EXPECT_EQ(nebula::meta::extractPatternMacro("date hourminute"), nebula::meta::PatternMacro::MINUTE);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("MINUTELY"), nebula::meta::PatternMacro::MINUTELY);
 
-  EXPECT_EQ(nebula::meta::extractPatternMacro("date hour #minute-second"), nebula::meta::PatternMacro::SECOND);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("SECONDLY"), nebula::meta::PatternMacro::SECONDLY);
 
   EXPECT_EQ(nebula::meta::extractPatternMacro("timestamp"), nebula::meta::PatternMacro::TIMESTAMP);
-  // has to be ts along
-  EXPECT_EQ(nebula::meta::extractPatternMacro("timestamp second"), nebula::meta::PatternMacro::INVALID);
 
-  EXPECT_EQ(nebula::meta::extractPatternMacro("dATE"), nebula::meta::PatternMacro::INVALID);
+  EXPECT_EQ(nebula::meta::extractPatternMacro("DATE"), nebula::meta::PatternMacro::INVALID);
   // has to be date/hour/minute/second
   EXPECT_EQ(nebula::meta::extractPatternMacro("second"), nebula::meta::PatternMacro::INVALID);
   EXPECT_EQ(nebula::meta::extractPatternMacro("hour"), nebula::meta::PatternMacro::INVALID);

--- a/src/service/server/LoadHandler.cpp
+++ b/src/service/server/LoadHandler.cpp
@@ -55,10 +55,10 @@ using nebula::service::base::GoogleSheet;
 using nebula::service::base::LoadSpec;
 
 size_t LoadHandler::extractWatermark(const common::unordered_map<std::string_view, std::string_view>& p) {
-  const auto datePattern = meta::patternYMLStr.at(meta::PatternMacro::DATE);
-  const auto hourPattern = meta::patternYMLStr.at(meta::PatternMacro::HOUR);
-  const auto minutePattern = meta::patternYMLStr.at(meta::PatternMacro::MINUTE);
-  const auto secondPattern = meta::patternYMLStr.at(meta::PatternMacro::SECOND);
+  const auto datePattern = meta::patternMacroStr.at(meta::PatternMacro::DAILY);
+  const auto hourPattern = meta::patternMacroStr.at(meta::PatternMacro::HOURLY);
+  const auto minutePattern = meta::patternMacroStr.at(meta::PatternMacro::MINUTELY);
+  const auto secondPattern = meta::patternMacroStr.at(meta::PatternMacro::SECONDLY);
 
   const auto dd = p.find(datePattern);
   const auto dh = p.find(hourPattern);


### PR DESCRIPTION
backward compatible
- make pattern date DATE and path template macros {date} {DATE} case insensitive during spec gen