### PR TITLE
ingestion udf schema change sample

### DIFF
--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -27,6 +27,15 @@ tables:
     max-mb: 10000
     max-hr: 240
     schema: "ROW<id:int, event:string, items:list<string>, flag:bool, value:tinyint>"
+    transformer:
+      schema: "ROW<id:int, event:string, item:string, flag:bool, value:tinyint, ts:long>"
+      udfs:
+        id: TO_INT
+        items: EXPLODE
+        ts: UNIX_TIMESTAMP
+      downsample:
+        id: 0.1
+        event: [ "a" ]
     data: custom
     loader: NebulaTest
     source: ""


### PR DESCRIPTION
In short term, we want to be able take 
- nested row that not yet supported by nebula and convert to flat rows
- timestamp and other datatypes to unix_timestamp
- string and binary to numerical value if possible to save space
- downsample logic based on percentage of a column and filter by event type 

Limitations:
- don't support udf taking two or more columns
- DataType system still seems not incorporate with ansi sql while rest of structured data systems are.

@shawncao what do you think
