### PR TITLE
Replaced all occurrences in the file headers

### DIFF
--- a/src/api/dsl/Base.cpp
+++ b/src/api/dsl/Base.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Base.h
+++ b/src/api/dsl/Base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Dsl.cpp
+++ b/src/api/dsl/Dsl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Dsl.h
+++ b/src/api/dsl/Dsl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Expressions.cpp
+++ b/src/api/dsl/Expressions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Expressions.h
+++ b/src/api/dsl/Expressions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Query.h
+++ b/src/api/dsl/Query.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Serde.cpp
+++ b/src/api/dsl/Serde.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dsl/Serde.h
+++ b/src/api/dsl/Serde.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/Test.cpp
+++ b/src/api/test/Test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/Test.hpp
+++ b/src/api/test/Test.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/TestApi.cpp
+++ b/src/api/test/TestApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/TestExpressions.cpp
+++ b/src/api/test/TestExpressions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/TestQuery.cpp
+++ b/src/api/test/TestQuery.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/test/TestUdf.cpp
+++ b/src/api/test/TestUdf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Avg.cpp
+++ b/src/api/udf/Avg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Avg.h
+++ b/src/api/udf/Avg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Between.h
+++ b/src/api/udf/Between.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Cardinality.h
+++ b/src/api/udf/Cardinality.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Count.h
+++ b/src/api/udf/Count.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Histogram.h
+++ b/src/api/udf/Histogram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/In.h
+++ b/src/api/udf/In.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Like.cpp
+++ b/src/api/udf/Like.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Like.h
+++ b/src/api/udf/Like.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Max.h
+++ b/src/api/udf/Max.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Min.h
+++ b/src/api/udf/Min.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Not.h
+++ b/src/api/udf/Not.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Pct.h
+++ b/src/api/udf/Pct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Prefix.h
+++ b/src/api/udf/Prefix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Sum.cpp
+++ b/src/api/udf/Sum.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Sum.h
+++ b/src/api/udf/Sum.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/Tpm.h
+++ b/src/api/udf/Tpm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/udf/UDFFactory.h
+++ b/src/api/udf/UDFFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Bits.h
+++ b/src/common/Bits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/BloomFilter.h
+++ b/src/common/BloomFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Chars.h
+++ b/src/common/Chars.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Conv.h
+++ b/src/common/Conv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/CountMin.h
+++ b/src/common/CountMin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Cursor.h
+++ b/src/common/Cursor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Delta.h
+++ b/src/common/Delta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Errors.cpp
+++ b/src/common/Errors.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Errors.h
+++ b/src/common/Errors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Evidence.h
+++ b/src/common/Evidence.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Finally.h
+++ b/src/common/Finally.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Fold.h
+++ b/src/common/Fold.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Folly.h
+++ b/src/common/Folly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Format.h
+++ b/src/common/Format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Hash.h
+++ b/src/common/Hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/HashRing.h
+++ b/src/common/HashRing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/HyperLogLog.h
+++ b/src/common/HyperLogLog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/IStream.h
+++ b/src/common/IStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Identifiable.h
+++ b/src/common/Identifiable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Int128.cpp
+++ b/src/common/Int128.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Int128.h
+++ b/src/common/Int128.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Ip.h
+++ b/src/common/Ip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Likely.h
+++ b/src/common/Likely.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Memory.cpp
+++ b/src/common/Memory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Memory.h
+++ b/src/common/Memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Params.h
+++ b/src/common/Params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Spark.h
+++ b/src/common/Spark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/StackTree.h
+++ b/src/common/StackTree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Task.h
+++ b/src/common/Task.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/TaskScheduler.h
+++ b/src/common/TaskScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/Zip.h
+++ b/src/common/Zip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestCommon.cpp
+++ b/src/common/test/TestCommon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestCompression.cpp
+++ b/src/common/test/TestCompression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestDistAlgo.cpp
+++ b/src/common/test/TestDistAlgo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestExts.cpp
+++ b/src/common/test/TestExts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestHash.cpp
+++ b/src/common/test/TestHash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestIpAddr.cpp
+++ b/src/common/test/TestIpAddr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestJs.cpp
+++ b/src/common/test/TestJs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestMetaDB.cpp
+++ b/src/common/test/TestMetaDB.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestSimd.cpp
+++ b/src/common/test/TestSimd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestSlice.cpp
+++ b/src/common/test/TestSlice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/test/TestStatsAlgo.cpp
+++ b/src/common/test/TestStatsAlgo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/BlockManager.cpp
+++ b/src/execution/BlockManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/BlockManager.h
+++ b/src/execution/BlockManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/Context.h
+++ b/src/execution/Context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/ExecutionPlan.cpp
+++ b/src/execution/ExecutionPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/ExecutionPlan.h
+++ b/src/execution/ExecutionPlan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/TableState.cpp
+++ b/src/execution/TableState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/TableState.h
+++ b/src/execution/TableState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/AggregationMerge.cpp
+++ b/src/execution/core/AggregationMerge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/AggregationMerge.h
+++ b/src/execution/core/AggregationMerge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/BlockExecutor.cpp
+++ b/src/execution/core/BlockExecutor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/BlockExecutor.h
+++ b/src/execution/core/BlockExecutor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/ComputedRow.cpp
+++ b/src/execution/core/ComputedRow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/ComputedRow.h
+++ b/src/execution/core/ComputedRow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/Finalize.cpp
+++ b/src/execution/core/Finalize.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/Finalize.h
+++ b/src/execution/core/Finalize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/NodeClient.cpp
+++ b/src/execution/core/NodeClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/NodeClient.h
+++ b/src/execution/core/NodeClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/NodeConnector.h
+++ b/src/execution/core/NodeConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/NodeExecutor.cpp
+++ b/src/execution/core/NodeExecutor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/NodeExecutor.h
+++ b/src/execution/core/NodeExecutor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/ReferenceRows.h
+++ b/src/execution/core/ReferenceRows.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/ServerExecutor.cpp
+++ b/src/execution/core/ServerExecutor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/ServerExecutor.h
+++ b/src/execution/core/ServerExecutor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/core/TopSort.h
+++ b/src/execution/core/TopSort.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/io/BlockLoader.cpp
+++ b/src/execution/io/BlockLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/io/BlockLoader.h
+++ b/src/execution/io/BlockLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/meta/TableService.cpp
+++ b/src/execution/meta/TableService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/meta/TableService.h
+++ b/src/execution/meta/TableService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/op/Operator.cpp
+++ b/src/execution/op/Operator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/op/Operator.h
+++ b/src/execution/op/Operator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/serde/RowCursorSerde.cpp
+++ b/src/execution/serde/RowCursorSerde.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/serde/RowCursorSerde.h
+++ b/src/execution/serde/RowCursorSerde.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/test/TestExec.cpp
+++ b/src/execution/test/TestExec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/test/TestOptimizedBlockExec.cpp
+++ b/src/execution/test/TestOptimizedBlockExec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/execution/test/TestValueEvalTree.cpp
+++ b/src/execution/test/TestValueEvalTree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/BlockExpire.h
+++ b/src/ingest/BlockExpire.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/IngestSpec.cpp
+++ b/src/ingest/IngestSpec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/IngestSpec.h
+++ b/src/ingest/IngestSpec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/SpecRepo.cpp
+++ b/src/ingest/SpecRepo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/SpecRepo.h
+++ b/src/ingest/SpecRepo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/TimeRow.h
+++ b/src/ingest/TimeRow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ingest/test/TestIngestion.cpp
+++ b/src/ingest/test/TestIngestion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/Accessor.cpp
+++ b/src/memory/Accessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/Batch.cpp
+++ b/src/memory/Batch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/Batch.h
+++ b/src/memory/Batch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/DataNode.cpp
+++ b/src/memory/DataNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/DataNode.h
+++ b/src/memory/DataNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/FlatRow.cpp
+++ b/src/memory/FlatRow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/FlatRow.h
+++ b/src/memory/FlatRow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/DictEncoder.h
+++ b/src/memory/encode/DictEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/RleDecoder.cpp
+++ b/src/memory/encode/RleDecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/RleDecoder.h
+++ b/src/memory/encode/RleDecoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/RleEncoder.cpp
+++ b/src/memory/encode/RleEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/RleEncoder.h
+++ b/src/memory/encode/RleEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/encode/Utils.h
+++ b/src/memory/encode/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/keyed/FlatBuffer.cpp
+++ b/src/memory/keyed/FlatBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/keyed/FlatBuffer.h
+++ b/src/memory/keyed/FlatBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/keyed/FlatRowCursor.h
+++ b/src/memory/keyed/FlatRowCursor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/keyed/HashFlat.cpp
+++ b/src/memory/keyed/HashFlat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/keyed/HashFlat.h
+++ b/src/memory/keyed/HashFlat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeData.cpp
+++ b/src/memory/serde/TypeData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeData.h
+++ b/src/memory/serde/TypeData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeDataFactory.cpp
+++ b/src/memory/serde/TypeDataFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeDataFactory.h
+++ b/src/memory/serde/TypeDataFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeMetadata.cpp
+++ b/src/memory/serde/TypeMetadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/serde/TypeMetadata.h
+++ b/src/memory/serde/TypeMetadata.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestArrow.cpp
+++ b/src/memory/test/TestArrow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestBatch.cpp
+++ b/src/memory/test/TestBatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestEncoder.cpp
+++ b/src/memory/test/TestEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestFlatBuffer.cpp
+++ b/src/memory/test/TestFlatBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestFlatRow.cpp
+++ b/src/memory/test/TestFlatRow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/memory/test/TestHistogram.cpp
+++ b/src/memory/test/TestHistogram.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Access.h
+++ b/src/meta/Access.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/ClusterInfo.cpp
+++ b/src/meta/ClusterInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/ClusterInfo.h
+++ b/src/meta/ClusterInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Macro.h
+++ b/src/meta/Macro.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/MetaDb.h
+++ b/src/meta/MetaDb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/MetaService.h
+++ b/src/meta/MetaService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/NBlock.h
+++ b/src/meta/NBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/NNode.h
+++ b/src/meta/NNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/NTime.h
+++ b/src/meta/NTime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/NodeManager.cpp
+++ b/src/meta/NodeManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/NodeManager.h
+++ b/src/meta/NodeManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Partition.h
+++ b/src/meta/Partition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Pod.h
+++ b/src/meta/Pod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Table.cpp
+++ b/src/meta/Table.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/Table.h
+++ b/src/meta/Table.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/TestTable.cpp
+++ b/src/meta/TestTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/TestTable.h
+++ b/src/meta/TestTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/test/TestMeta.cpp
+++ b/src/meta/test/TestMeta.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/meta/test/TestPartition.cpp
+++ b/src/meta/test/TestPartition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/GoogleSheet.h
+++ b/src/service/base/GoogleSheet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/LoadSpec.h
+++ b/src/service/base/LoadSpec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/NativeMetaDb.cpp
+++ b/src/service/base/NativeMetaDb.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/NativeMetaDb.h
+++ b/src/service/base/NativeMetaDb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/NebulaService.cpp
+++ b/src/service/base/NebulaService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/base/NebulaService.h
+++ b/src/service/base/NebulaService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/client/NebulaClient.cpp
+++ b/src/service/client/NebulaClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/client/NebulaClient.h
+++ b/src/service/client/NebulaClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/_/api.js
+++ b/src/service/http/nebula/_/api.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/_/handler.js
+++ b/src/service/http/nebula/_/handler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/_/serde.js
+++ b/src/service/http/nebula/_/serde.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/_/time.js
+++ b/src/service/http/nebula/_/time.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/__/sdk.js
+++ b/src/service/http/nebula/__/sdk.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/__/state.js
+++ b/src/service/http/nebula/__/state.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/c/charts.js
+++ b/src/service/http/nebula/c/charts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/c/charts2.js
+++ b/src/service/http/nebula/c/charts2.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/c/color.js
+++ b/src/service/http/nebula/c/color.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/c/constraints.js
+++ b/src/service/http/nebula/c/constraints.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/c/flame.js
+++ b/src/service/http/nebula/c/flame.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/dist/node/main.cjs
+++ b/src/service/http/nebula/dist/node/main.cjs
@@ -5067,7 +5067,7 @@ module.exports = require("grpc");
 
 // Original file comments:
 //
-// Copyright 2017-present Shawn Cao
+// Copyright 2017-present varchar.io
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/index.cjs
+++ b/src/service/http/nebula/index.cjs
@@ -5073,7 +5073,7 @@ module.exports = require("json-bigint");
 
 // Original file comments:
 //
-// Copyright 2017-present Shawn Cao
+// Copyright 2017-present varchar.io
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -5378,7 +5378,7 @@ var external_stream_ = __webpack_require__(4);
 
 // CONCATENATED MODULE: ./_/handler.js
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -5473,7 +5473,7 @@ class handler_Handler {
 };
 // CONCATENATED MODULE: ./_/serde.js
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -5517,7 +5517,7 @@ const bytes2utf8 = (data) => {
 };
 // CONCATENATED MODULE: ./_/time.js
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/node.js
+++ b/src/service/http/nebula/node.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/w/client.js
+++ b/src/service/http/nebula/w/client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/w/client2.js
+++ b/src/service/http/nebula/w/client2.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/http/nebula/web.js
+++ b/src/service/http/nebula/web.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/ConnectionPool.cpp
+++ b/src/service/node/ConnectionPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/ConnectionPool.h
+++ b/src/service/node/ConnectionPool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/NodeClient.cpp
+++ b/src/service/node/NodeClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/NodeClient.h
+++ b/src/service/node/NodeClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/NodeServer.cpp
+++ b/src/service/node/NodeServer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/NodeServer.h
+++ b/src/service/node/NodeServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/RemoteNodeConnector.h
+++ b/src/service/node/RemoteNodeConnector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/TaskExecutor.cpp
+++ b/src/service/node/TaskExecutor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/node/TaskExecutor.h
+++ b/src/service/node/TaskExecutor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/protos/nebula.proto
+++ b/src/service/protos/nebula.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/LoadHandler.cpp
+++ b/src/service/server/LoadHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/LoadHandler.h
+++ b/src/service/server/LoadHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/NebulaServer.cpp
+++ b/src/service/server/NebulaServer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/NebulaServer.h
+++ b/src/service/server/NebulaServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/NodeSync.cpp
+++ b/src/service/server/NodeSync.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/NodeSync.h
+++ b/src/service/server/NodeSync.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/QueryHandler.cpp
+++ b/src/service/server/QueryHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/server/QueryHandler.h
+++ b/src/service/server/QueryHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/test/TestQueryHandler.cpp
+++ b/src/service/test/TestQueryHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/service/test/TestQueryService.cpp
+++ b/src/service/test/TestQueryService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/CsvReader.cpp
+++ b/src/storage/CsvReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/CsvReader.h
+++ b/src/storage/CsvReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/JsonReader.h
+++ b/src/storage/JsonReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/NFS.cpp
+++ b/src/storage/NFS.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/NFS.h
+++ b/src/storage/NFS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/NFileSystem.h
+++ b/src/storage/NFileSystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/ParquetReader.cpp
+++ b/src/storage/ParquetReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/ParquetReader.h
+++ b/src/storage/ParquetReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/RowParser.h
+++ b/src/storage/RowParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/ThriftReader.cpp
+++ b/src/storage/ThriftReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/ThriftReader.h
+++ b/src/storage/ThriftReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/VectorReader.h
+++ b/src/storage/VectorReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/aws/S3.cpp
+++ b/src/storage/aws/S3.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/aws/S3.h
+++ b/src/storage/aws/S3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/http/Http.cpp
+++ b/src/storage/http/Http.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/http/Http.h
+++ b/src/storage/http/Http.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaProvider.cpp
+++ b/src/storage/kafka/KafkaProvider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaProvider.h
+++ b/src/storage/kafka/KafkaProvider.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaReader.cpp
+++ b/src/storage/kafka/KafkaReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaReader.h
+++ b/src/storage/kafka/KafkaReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaTopic.cpp
+++ b/src/storage/kafka/KafkaTopic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/kafka/KafkaTopic.h
+++ b/src/storage/kafka/KafkaTopic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/local/File.cpp
+++ b/src/storage/local/File.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/local/File.h
+++ b/src/storage/local/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestHttp.cpp
+++ b/src/storage/test/TestHttp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestJsonReader.cpp
+++ b/src/storage/test/TestJsonReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestKafka.cpp
+++ b/src/storage/test/TestKafka.cpp
@@ -1,5 +1,5 @@
   /*
-  * Copyright 2017-present Shawn Cao
+  * Copyright 2017-present varchar.io
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestParquet.cpp
+++ b/src/storage/test/TestParquet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestStorage.cpp
+++ b/src/storage/test/TestStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/storage/test/TestVectorReader.cpp
+++ b/src/storage/test/TestVectorReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/DataSurface.h
+++ b/src/surface/DataSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/MockSurface.cpp
+++ b/src/surface/MockSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/MockSurface.h
+++ b/src/surface/MockSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/SchemaRow.h
+++ b/src/surface/SchemaRow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/StaticData.h
+++ b/src/surface/StaticData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/TopRows.h
+++ b/src/surface/TopRows.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Aggregator.h
+++ b/src/surface/eval/Aggregator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Block.h
+++ b/src/surface/eval/Block.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/EvalContext.cpp
+++ b/src/surface/eval/EvalContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/EvalContext.h
+++ b/src/surface/eval/EvalContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Histogram.cpp
+++ b/src/surface/eval/Histogram.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Histogram.h
+++ b/src/surface/eval/Histogram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Operation.h
+++ b/src/surface/eval/Operation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/Script.h
+++ b/src/surface/eval/Script.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/UDF.h
+++ b/src/surface/eval/UDF.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/ValueEval.cpp
+++ b/src/surface/eval/ValueEval.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/eval/ValueEval.h
+++ b/src/surface/eval/ValueEval.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/test/TestHistogram.cpp
+++ b/src/surface/test/TestHistogram.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/surface/test/TestSurface.cpp
+++ b/src/surface/test/TestSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/Serde.cpp
+++ b/src/type/Serde.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/Serde.h
+++ b/src/type/Serde.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/Tree.h
+++ b/src/type/Tree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/Type.h
+++ b/src/type/Type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/test/TestMisc.cpp
+++ b/src/type/test/TestMisc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/type/test/TestType.cpp
+++ b/src/type/test/TestType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Shawn Cao
+ * Copyright 2017-present varchar.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
From Copyright 2017-present Shawn Cao to Copyright 2017-present varchar.io. Related to issue #85 