### PR TITLE
fix histogram 0 bucket size crash case

### DIFF
--- a/src/api/udf/Histogram.h
+++ b/src/api/udf/Histogram.h
@@ -180,7 +180,6 @@ public:
                  }
 
                  // push upbound if the range is not ideal - it's okay to modify max
-
                  if constexpr (std::is_floating_point_v<InputType>) {
                    if (upbound - lowbound < DOUBLE_BUCKET_PRECISION) {
                      upbound = lowbound + DOUBLE_BUCKET_PRECISION;

--- a/src/api/udf/Histogram.h
+++ b/src/api/udf/Histogram.h
@@ -34,6 +34,7 @@ template <nebula::type::Kind IK,
 class Hist : public BaseType {
   // Set default number of buckets to 10
   static constexpr size_t BUCKET_NUM = 10;
+  static constexpr double DOUBLE_BUCKET_PRECISION = 0.001;
 
 public:
   using InputType = typename std::conditional_t<std::is_floating_point_v<typename BaseType::InputType>, double, int64_t>;
@@ -42,15 +43,15 @@ public:
 
 public:
   class Aggregator : public BaseAggregator {
-  static constexpr auto SIZE_SIZE = sizeof(size_t);
+    static constexpr auto SIZE_SIZE = sizeof(size_t);
 
   public:
-    explicit Aggregator(InputType min, InputType max, size_t bucketNum = BUCKET_NUM)
+    explicit Aggregator(InputType min, InputType max, size_t bucketNum)
       : min_{ min },
-      max_{ max },
-      bucketNum_{ bucketNum },
-      bucketSize_{ static_cast<InputType>((max_ - min_) / bucketNum) },
-      histogram_{ bucketSize_, min_, max_ } {
+        max_{ max },
+        bucketNum_{ bucketNum },
+        bucketSize_{ static_cast<InputType>((max_ - min_) / bucketNum) },
+        histogram_{ bucketSize_, min_, max_ } {
     }
     virtual ~Aggregator() = default;
 
@@ -116,11 +117,11 @@ public:
     folly::Histogram<InputType> histogram_;
     std::string json_;
 
-#define SAVE_VALUE(value) \
-  if constexpr (std::is_floating_point_v<InputType>) {    \
-    json.Double(value);                                        \
-  } else {                                                     \
-    json.Int64(value);                                         \
+#define SAVE_VALUE(value)                              \
+  if constexpr (std::is_floating_point_v<InputType>) { \
+    json.Double(value);                                \
+  } else {                                             \
+    json.Int64(value);                                 \
   }
     std::string jsonfy(bool finalize = false) const noexcept {
       // Save histogram in below json format:
@@ -159,12 +160,40 @@ public:
     }
 #undef SAVE_VALUE
   };
+
 public:
-  Hist(const std::string& name, std::unique_ptr<nebula::surface::eval::ValueEval> expr, InputType min, InputType max)
+  Hist(const std::string& name,
+       std::unique_ptr<nebula::surface::eval::ValueEval> expr,
+       InputType min,
+       InputType max,
+       size_t bucketNum = BUCKET_NUM)
     : BaseType(name,
                std::move(expr),
-               [min = min, max = max]() -> std::shared_ptr<Aggregator> {
-                 return std::make_shared<Aggregator>(min, max);
+               [min, max, bucketNum]() -> std::shared_ptr<Aggregator> {
+                 auto lowbound = min;
+                 auto upbound = max;
+                 // preventive handling min > max (if the data has invalid range - wrong stats)
+                 // reset both to 0 to have basic bucket settings by following logic
+                 if (upbound < lowbound) {
+                   lowbound = 0;
+                   upbound = 0;
+                 }
+
+                 // push upbound if the range is not ideal - it's okay to modify max
+
+                 if constexpr (std::is_floating_point_v<InputType>) {
+                   if (upbound - lowbound < DOUBLE_BUCKET_PRECISION) {
+                     upbound = lowbound + DOUBLE_BUCKET_PRECISION;
+                   }
+                 } else {
+                   // for integer - we need at least 1 for each bucket
+                   const size_t delta = upbound - lowbound;
+                   if (delta < bucketNum) {
+                     upbound = lowbound + bucketNum;
+                   }
+                 }
+
+                 return std::make_shared<Aggregator>(lowbound, upbound, bucketNum);
                }) {}
 
   virtual ~Hist() = default;

--- a/src/api/udf/Max.h
+++ b/src/api/udf/Max.h
@@ -94,9 +94,9 @@ class Max<nebula::type::Kind::VARCHAR> : public nebula::surface::eval::UDAF<nebu
 public:
   Max(const std::string& name, std::unique_ptr<nebula::surface::eval::ValueEval> expr)
     : nebula::surface::eval::UDAF<nebula::type::Kind::VARCHAR, nebula::type::Kind::VARCHAR>(
-        name,
-        std::move(expr),
-        {}) {
+      name,
+      std::move(expr),
+      {}) {
     throw NException("Not supporting max(varchar) yet.");
   }
   virtual ~Max() = default;

--- a/src/common/test/TestCommon.cpp
+++ b/src/common/test/TestCommon.cpp
@@ -252,6 +252,18 @@ TEST(CommonTest, TestTimeParsing) {
   }
 }
 
+TEST(CommonTest, Test0AndOverflow) {
+  int64_t min = 0, max = 0;
+  size_t size = 100;
+  const size_t delta = max - min;
+  if (delta < size) {
+    max = min + size;
+  }
+
+  LOG(INFO) << "min=" << min << ", max=" << max << ", delta=" << delta;
+  EXPECT_TRUE(min < max);
+}
+
 TEST(CommonTest, TestSerialNumberTime) {
   auto serial = 43386;
   auto date = "10/13/2018";

--- a/src/common/test/TestStatsAlgo.cpp
+++ b/src/common/test/TestStatsAlgo.cpp
@@ -37,6 +37,16 @@ namespace common {
 namespace test {
 
 TEST(StatsTest, TestHistogram) {
+  // error input
+  {
+    // internal check:
+    // 1) bucket size > 0
+    // 2) min < max
+    folly::Histogram<int64_t> hist(1, 0, 1);
+    hist.addValue(0);
+    EXPECT_EQ(hist.getNumBuckets(), 3);
+  }
+
   // basic histogram functions
   {
     // construct histogram object with (bucketSize, minValue, maxValue)


### PR DESCRIPTION
This fix is to add error preventive handling in the data structure to avoid invalid input to crash the expectation.

fix #87 