### PR TITLE
unenroll a table name if load fails

### DIFF
--- a/src/execution/meta/TableService.h
+++ b/src/execution/meta/TableService.h
@@ -80,6 +80,10 @@ public:
     }
   }
 
+  inline void unenroll(const std::string& name) {
+    tables_.erase(name);
+  }
+
   // enroll/refresh tables from the whole cluster info
   void enroll(const nebula::meta::ClusterInfo&);
 

--- a/src/service/server/NebulaServer.cpp
+++ b/src/service/server/NebulaServer.cpp
@@ -294,6 +294,9 @@ Status V1ServiceImpl::Load(ServerContext* ctx, const LoadRequest* req, LoadRespo
     return Status::OK;
   }
 
+  // unregister the table if the load failed
+  TableService::singleton()->unenroll(tableName);
+
   reply->set_error(LoadError::TEMPLATE_NOT_FOUND);
   return Status::CANCELLED;
 }


### PR DESCRIPTION
quick fix: if failed in data loading - unenroll the table so that it can retry.