### PR TITLE
enable Nebula to ingest data source from a given HTTP URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,9 @@ find_package(Boost MODULE
     system
     thread
   REQUIRED)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
 
 # find glog
 # target: glog::glog

--- a/ext/Grpc_Ext.cmake
+++ b/ext/Grpc_Ext.cmake
@@ -69,8 +69,7 @@ add_dependencies(${CARES_LIBRARY} c-ares)
 #         return ::grpc::Status(::grpc::StatusCode::INTERNAL, "No payload");
 #       }
 SET(FB_OPTS
-  -DFLATBUFFERS_BUILD_TESTS:BOOL=OFF
-  -DFLATBUFFERS_STATIC_FLATC:BOOL=ON)
+  -DFLATBUFFERS_BUILD_TESTS:BOOL=OFF)
 ExternalProject_Add(flatbuffers
   PREFIX flatbuffers
   GIT_REPOSITORY https://github.com/google/flatbuffers.git

--- a/src/ingest/IngestSpec.cpp
+++ b/src/ingest/IngestSpec.cpp
@@ -270,7 +270,7 @@ bool IngestSpec::loadHttp(BlockList& blocks) noexcept {
   }
 
   // the sheet content in this json objects
-  if (!http.downlaod(url, headers, tmpFile)) {
+  if (!http.download(url, headers, tmpFile)) {
     LOG(WARNING) << "Failed to download to local: " << path_;
     return false;
   }

--- a/src/ingest/IngestSpec.h
+++ b/src/ingest/IngestSpec.h
@@ -155,6 +155,9 @@ private:
   // load google sheet
   bool loadGSheet(nebula::execution::io::BlockList& blocks) noexcept;
 
+  // load an http resource
+  bool loadHttp(nebula::execution::io::BlockList& blocks) noexcept;
+
   // load current spec as blocks
   bool load(nebula::execution::io::BlockList&) noexcept;
 

--- a/src/meta/ClusterInfo.cpp
+++ b/src/meta/ClusterInfo.cpp
@@ -83,26 +83,6 @@ using nebula::common::Evidence;
 using nebula::common::unordered_map;
 using nebula::type::TypeSerializer;
 
-DataSource asDataSource(const std::string& data) {
-  if (data == "custom") {
-    return DataSource::Custom;
-  }
-
-  if (data == "s3") {
-    return DataSource::S3;
-  }
-
-  if (data == "kafka") {
-    return DataSource::KAFKA;
-  }
-
-  if (data == "local") {
-    return DataSource::LOCAL;
-  }
-
-  throw NException("Misconfigured data source");
-}
-
 AccessType asAccessType(const std::string& name) {
   if (name == "read") return AccessType::READ;
   if (name == "aggregation") return AccessType::AGGREGATION;
@@ -347,7 +327,7 @@ void ClusterInfo::load(const std::string& file, CreateMetaDB createDb) {
 
     // table definition
     const auto& td = it->second;
-    auto ds = asDataSource(td["data"].as<std::string>());
+    auto ds = DataSourceUtils::from(td["data"].as<std::string>());
 
     // TODO(cao): sorry but we have a hard rule here,
     // every Kafka table will be named as "k.{topic_name}"

--- a/src/meta/test/TestMeta.cpp
+++ b/src/meta/test/TestMeta.cpp
@@ -21,7 +21,7 @@
 #include "meta/ClusterInfo.h"
 #include "meta/NBlock.h"
 #include "meta/Pod.h"
-#include "meta/Table.h"
+#include "meta/TableSpec.h"
 #include "meta/TestTable.h"
 #include "type/Serde.h"
 
@@ -61,6 +61,45 @@ TEST(MetaTest, TestNNode) {
   NNode n2{ n1 };
   ASSERT_TRUE(n1.equals(n2));
   LOG(INFO) << "N2=" << n2.toString();
+}
+
+TEST(MetaTest, TestDataSource) {
+  using ds = nebula::meta::DataSource;
+  using dsu = nebula::meta::DataSourceUtils;
+
+  // test isFileSystem
+  {
+    EXPECT_TRUE(dsu::isFileSystem(ds::S3));
+    EXPECT_TRUE(dsu::isFileSystem(ds::GS));
+    EXPECT_TRUE(dsu::isFileSystem(ds::LOCAL));
+    EXPECT_FALSE(dsu::isFileSystem(ds::HTTP));
+    EXPECT_FALSE(dsu::isFileSystem(ds::KAFKA));
+    EXPECT_FALSE(dsu::isFileSystem(ds::NEBULA));
+    EXPECT_FALSE(dsu::isFileSystem(ds::GSHEET));
+  }
+
+  // test get protocol
+  {
+    EXPECT_EQ("s3", dsu::getProtocol(ds::S3));
+    EXPECT_EQ("gs", dsu::getProtocol(ds::GS));
+    EXPECT_EQ("http", dsu::getProtocol(ds::HTTP));
+    EXPECT_EQ("local", dsu::getProtocol(ds::LOCAL));
+    EXPECT_EQ("", dsu::getProtocol(ds::KAFKA));
+    EXPECT_EQ("", dsu::getProtocol(ds::NEBULA));
+    EXPECT_EQ("", dsu::getProtocol(ds::GSHEET));
+  }
+
+  // test get data source from name
+  {
+    EXPECT_EQ(ds::S3, dsu::from("S3"));
+    EXPECT_EQ(ds::GS, dsu::from("gs"));
+    EXPECT_EQ(ds::HTTP, dsu::from("http"));
+    EXPECT_EQ(ds::HTTP, dsu::from("HTTPs"));
+    EXPECT_EQ(ds::LOCAL, dsu::from("local"));
+    EXPECT_EQ(ds::KAFKA, dsu::from("KAFKA"));
+    EXPECT_EQ(ds::NEBULA, dsu::from(""));
+    EXPECT_EQ(ds::NEBULA, dsu::from("xyz"));
+  }
 }
 
 TEST(MetaTest, TestClusterConfigLoad) {

--- a/src/service/base/LoadSpec.h
+++ b/src/service/base/LoadSpec.h
@@ -28,6 +28,10 @@ namespace nebula {
 namespace service {
 namespace base {
 
+// extract more info from a load spec
+struct LoadSpec;
+void extract(const std::string&, LoadSpec&);
+
 // client side will send a load spec to load
 // the spec definition is parsed from LoadRequest.json in nebula.proto
 struct LoadSpec {
@@ -47,6 +51,9 @@ struct LoadSpec {
 
   // data format - such as "csv"
   std::string format;
+
+  // optional access token
+  std::string token;
 
   // time spec of this load demand
   std::string tcol;
@@ -87,6 +94,7 @@ struct LoadSpec {
     READ_MEMBER("path", path, GetString)
     READ_MEMBER("schema", schema, GetString)
     READ_MEMBER("format", format, GetString)
+    READ_MEMBER("token", token, GetString)
 
     // time related
     READ_MEMBER("tcol", tcol, GetString)
@@ -94,16 +102,14 @@ struct LoadSpec {
 
     N_ENSURE(path.size() > 0, "data path is required");
     N_ENSURE(schema.size() > 0, "data schema is required");
-    N_ENSURE(format.size() > 0, "data schema is required");
+    N_ENSURE(format.size() > 0, "data format is required");
 
-    // detect data source
-    auto uri = nebula::storage::parse(path);
-    // TODO(cao): only support S3 for now
-    if (uri.schema == "s3") {
-      // create a s3 file system
-      source = nebula::meta::DataSource::S3;
-      domain = uri.host;
-      path = uri.path;
+    // extract other info such as source, domain, etc.
+    extract(path, *this);
+
+    // set access token if present through settings
+    if (!token.empty()) {
+      settings["token"] = token;
     }
 
     if (format == "csv") {
@@ -122,6 +128,21 @@ struct LoadSpec {
     }
   }
 };
+
+// extract other information from given path
+void extract(const std::string& path, LoadSpec& spec) {
+  // detect data source
+  auto uri = nebula::storage::parse(path);
+  const auto ds = nebula::meta::DataSourceUtils::from(uri.schema);
+
+  // custom data source is not allowed to be visible to external (API)
+  if (ds != nebula::meta::DataSource::NEBULA) {
+    spec.source = ds;
+    spec.domain = uri.host;
+    spec.path = uri.path;
+  }
+}
+
 } // namespace base
 } // namespace service
 } // namespace nebula

--- a/src/storage/http/Http.cpp
+++ b/src/storage/http/Http.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <glog/logging.h>
+#include <stdlib.h>
 
 #include "Http.h"
 
@@ -47,6 +48,21 @@ HttpService::~HttpService() {
   curl_ = nullptr;
 }
 
+#define SET_HTTP_HEADERS                                \
+  struct curl_slist* chunk = NULL;                      \
+  nebula::common::Finally releaseChunk([&chunk]() {     \
+    if (chunk) {                                        \
+      curl_slist_free_all(chunk);                       \
+    }                                                   \
+  });                                                   \
+                                                        \
+  if (!headers.empty()) {                               \
+    for (auto& header : headers) {                      \
+      chunk = curl_slist_append(chunk, header.c_str()); \
+    }                                                   \
+    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, chunk); \
+  }
+
 size_t read(void* data, size_t size, size_t nmemb, std::string* str) {
   size_t len = size * nmemb;
   str->append((char*)data, len);
@@ -67,20 +83,7 @@ std::string HttpService::readJson(const std::string& url, const std::vector<std:
   curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &json);
 
   // if custom headers are present - set them
-  struct curl_slist* chunk = NULL;
-  nebula::common::Finally releaseChunk([&chunk]() {
-    if (chunk) {
-      curl_slist_free_all(chunk);
-    }
-  });
-
-  if (!headers.empty()) {
-    for (auto& header : headers) {
-      chunk = curl_slist_append(chunk, header.c_str());
-    }
-
-    curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, chunk);
-  }
+  SET_HTTP_HEADERS
 
   // perform the request
   CURLcode res = curl_easy_perform(curl_);
@@ -104,6 +107,42 @@ std::string HttpService::readJson(const std::string& url, const std::vector<std:
 
   return json;
 }
+
+// buffering from curl and writing into the file (replace with ostream?)
+static size_t write(void* ptr, size_t size, size_t nmemb, void* stream) {
+  size_t written = fwrite(ptr, size, nmemb, (FILE*)stream);
+  return written;
+}
+
+// follow https://curl.se/libcurl/c/url2file.html
+bool HttpService::download(const std::string& url,
+                           const std::vector<std::string>& headers,
+                           const std::string& local) const {
+
+  // set the URL and perform
+  curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+
+  // if custom headers are present - set them
+  SET_HTTP_HEADERS
+
+  // no need progress
+  curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
+  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write);
+  // open the file for writing
+  FILE* pagefile = fopen(local, "wb");
+  if (pagefile) {
+    // start to write data
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, pagefile);
+
+    // perform the download action
+    curl_easy_perform(curl_handle);
+
+    // close the file
+    fclose(pagefile);
+  }
+}
+
+#undef SET_HTTP_HEADERS
 
 } // namespace http
 } // namespace storage

--- a/src/storage/http/Http.h
+++ b/src/storage/http/Http.h
@@ -42,7 +42,11 @@ public:
   virtual ~HttpService();
 
 public:
+  // read a URL as JSON data result
   std::string readJson(const std::string&, const std::vector<std::string>&) const;
+
+  // download a data file from given URL into a local file
+  bool download(const std::string&, const std::vector<std::string>&, const std::string&) const;
 
 private:
   CURL* curl_;

--- a/src/storage/test/TestHttp.cpp
+++ b/src/storage/test/TestHttp.cpp
@@ -33,6 +33,22 @@ TEST(HttpTest, TestBasicRead) {
   LOG(INFO) << "Content: " << json;
 }
 
+TEST(HttpTest, TestBasicDownload) {
+  auto url = "https://user-images.githubusercontent.com/26632293/103615010-a998c600-4ede-11eb-8b55-ee5dcd4e4026.png";
+  nebula::storage::http::HttpService http;
+  auto fs = nebula::storage::makeFS("local");
+  auto tmpFile = local->temp();
+  bool r = http.download(url,
+                         { "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36" },
+                         tmpFile);
+  // this download should be always true
+  EXPECT_TRUE(r);
+
+  // check the file size
+  auto info = fs->info(tmpFile);
+  EXPECT_EQ(info.size, 476920);
+}
+
 TEST(HttpTest, TestReadGoogleSheets) {
   auto url = "https://sheets.googleapis.com/v4/spreadsheets/10FP5MEDG-iGtWO8y4Wd6dyKSHcETg4sKCkBFf8DvqFQ/values:batchGet?majorDimension=COLUMNS&ranges=A%3AZ&key=AIzaSyDdDCIglhCzcSz6lXEoq9qNekfL4C7Jx2A";
   nebula::storage::http::HttpService http;

--- a/src/storage/test/TestHttp.cpp
+++ b/src/storage/test/TestHttp.cpp
@@ -18,6 +18,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "storage/NFS.h"
 #include "storage/http/Http.h"
 
 namespace nebula {
@@ -37,7 +38,7 @@ TEST(HttpTest, TestBasicDownload) {
   auto url = "https://user-images.githubusercontent.com/26632293/103615010-a998c600-4ede-11eb-8b55-ee5dcd4e4026.png";
   nebula::storage::http::HttpService http;
   auto fs = nebula::storage::makeFS("local");
-  auto tmpFile = local->temp();
+  auto tmpFile = fs->temp();
   bool r = http.download(url,
                          { "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36" },
                          tmpFile);


### PR DESCRIPTION
This is work to enable Nebula to consume HTTP resources. 

Right now, this is only enabled for on-demand loading API, not opened for configured cluster as we haven't had data splitting logic for HTTP yet, to support planned ingestion, we have to define a interface to allow HTTP methods to provide planning info, and parameters to chunk all data into separate http calls.