### PR TITLE
Allow send spec of table definition into nebula runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ For example, this config section will ask Nebula to connect one Kafka topic for 
       max-hr: 48
     schema: "ROW<service:string, host:string, tag:string, lang:string, stack:string>"
     data: kafka
-    topic: <topic>
     loader: Streaming
     source: <brokers>
     backup: s3://nebula/n116/
     format: json
+    kafka:
+      topic: <topic>
     columns:
       service:
         dict: true

--- a/docs/docs/basics/1-overview.md
+++ b/docs/docs/basics/1-overview.md
@@ -253,15 +253,16 @@ To illustrate how to configure new data source in Nebula, here are some examples
     max-hr: 12
     schema: "ROW<userId:long, type:short, statusCode:byte, objectCount:int>"
     data: kafka
-    topic: <topic>
     loader: Streaming
     source: <brokers>
     backup: s3://nebula/n105/
     format: thrift
-    serde:
+    kafka:
+      topic: <topic>
       retention: 90000
+    thrift:
       protocol: binary
-      cmap:
+      columnsMap:
         _time_: 1
         userId: 3001
         type: 3003

--- a/docs/docs/configs/1-common.md
+++ b/docs/docs/configs/1-common.md
@@ -141,10 +141,11 @@ another example, let's look at how Kafka works
 tables:
   table-name-1:
     data: kafka
-    topic: topic-1
     loader: Streaming
     source: <brokers>
     backup: s3://nebula/n116/
+    kafka:
+      topic: topic-1
 ```
 in this case, `source` is used to place Kafka broker list that Nebula could connect to fetch data from `topic-1`.
 

--- a/docs/docs/configs/2-formats.md
+++ b/docs/docs/configs/2-formats.md
@@ -107,11 +107,12 @@ tables:
       max-hr: 12
     schema: "ROW<userId:long, magicType:short, statusCode:byte, objectCount:int>"
     data: kafka
-    topic: homefeed
     loader: Streaming
     source: kafkabroker.home.01
     backup: s3://nebula/n105/
     format: thrift
+    kafka:
+      topic: homefeed
     thrift:
       protocol: binary    
       columnsMap:

--- a/docs/docs/configs/3-connect_kafka.md
+++ b/docs/docs/configs/3-connect_kafka.md
@@ -17,11 +17,12 @@ Also you need a DNS address to connect their brokers, usually with port 9092.
       max-hr: 24
     schema: "ROW<name:string, value:int>"
     data: kafka
-    topic: test2
     loader: Streaming
     source: <BROKER ADDRESS>
     backup: s3://nebula/n116/
     format: json
+    kafka:
+      topic: test2
     columns:
       name:
         dict: true

--- a/src/configs/cluster.yml
+++ b/src/configs/cluster.yml
@@ -93,11 +93,12 @@ tables:
   #     max-hr: 48
   #   schema: "ROW<service:string, host:string, tag:string, lang:string, stack:string>"
   #   data: kafka
-  #   topic: <topic>
   #   loader: Streaming
   #   source: <brokers>
   #   backup: s3://nebula/n116/
   #   format: json
+  #   kafka:
+  #     topic: <topic>
   #   columns:
   #     service:
   #       dict: true
@@ -159,16 +160,16 @@ tables:
   #   # TODO(cao): in the future, we can have separate thrift schema
   #   schema: "ROW<userId:long, magicType:short, statusCode:byte, objectCount:int>"
   #   data: kafka
-  #   topic: <topic>
   #   loader: Streaming
   #   source: <brokers>
   #   backup: s3://nebula/n105/
   #   format: thrift
-  #   serde:
+  #   kafka:
+  #     topic: <topic>
   #     topic-retention: 90000
+  #   thrift:
   #     protocol: binary
-  #     cmap:
-  #       # TODO(cao): this temporary hack to work around nested thrift definition
+  #     columnsMap:
   #       # we're using 1K to separate two levels asssuming no thrift definition has more than 1K fields
   #       # in reverse order, such as 1003 => (field 3 -> field 1)
   #       _time_: 1
@@ -193,11 +194,12 @@ tables:
   #     max-hr: 1
   #   schema: "ROW<time:long, ct:int, actor_id:string, pid:long, app:byte, eventtype:string, owner:long, root_id:long, crated:long, version:short, slot:int>"
   #   data: kafka
-  #   topic: <topic>
   #   loader: Streaming
   #   source: <brokers>
   #   backup: s3://nebula/n115/
   #   format: json
+  #   kafka:
+  #     topic: <topic>
   #   columns:
   #     pid:
   #       bloom_filter: true

--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -28,7 +28,7 @@ tables:
       max-mb: 10000
       max-hr: 240
     schema: "ROW<id:int, event:string, items:list<string>, flag:bool, value:tinyint>"
-    data: custom
+    data: local
     loader: NebulaTest
     source: ""
     backup: s3://nebula/n100/

--- a/src/ingest/SpecRepo.cpp
+++ b/src/ingest/SpecRepo.cpp
@@ -198,7 +198,7 @@ void genKafkaSpec(const std::string& version,
   // visit each partition of the topic and figure out range for each spec
   // stream is different as static file, to make it reproducible, we need
   // a stable spec generation based on offsets, every N (eg. 10K) records per spec
-  KafkaTopic topic(table->location, table->name, table->kafkaSerde, table->settings, FLAGS_KAFKA_TIMEOUT_MS);
+  KafkaTopic topic(table->location, table->kafkaSerde, table->settings, FLAGS_KAFKA_TIMEOUT_MS);
 
   // check if this table has set batch size to overwrite the default one
   const auto& settings = table->settings;

--- a/src/meta/ClusterInfo.cpp
+++ b/src/meta/ClusterInfo.cpp
@@ -435,6 +435,7 @@ void ClusterInfo::load(const std::string& file, CreateMetaDB createDb) {
 
   // swap with new table set
   std::swap(tables_, tableSet);
+  stateChanged_ = false;
 
   // if user mistakenly config things at top level
   // (I made mistake to place a new table the same level as "tables")
@@ -459,6 +460,7 @@ std::string ClusterInfo::addTable(const std::string& table, const std::string& y
 
   // overwrite - emplace will not overwrite if key exists
   runtimeTables_[table] = std::move(tableDef);
+  stateChanged_ = true;
   return {};
 }
 

--- a/src/meta/ClusterInfo.cpp
+++ b/src/meta/ClusterInfo.cpp
@@ -89,6 +89,8 @@ namespace nebula {
 namespace meta {
 
 using nebula::common::Evidence;
+using nebula::common::unordered_map;
+using nebula::common::unordered_set;
 using nebula::type::TypeSerializer;
 
 AccessType asAccessType(const std::string& name) {
@@ -245,21 +247,25 @@ std::unordered_map<std::string, Column> asColumnProps(const YAML::Node& node) {
   return props;
 }
 
-KafkaSerde asSerde(const YAML::Node& node) {
-  KafkaSerde serde;
+KafkaSerde asKafka(const YAML::Node& node) {
+  KafkaSerde kafka;
   if (node) {
     // kafka topic retention time
     auto retention = node["topic-retention"];
     if (retention) {
-      serde.retention = retention.as<uint64_t>();
+      kafka.retention = retention.as<uint64_t>();
     }
+
     auto size = node["size"];
     if (size) {
-      serde.size = size.as<uint64_t>();
+      kafka.size = size.as<uint64_t>();
     }
+
+    // topic is a must to have
+    kafka.topic = node["topic"].as<std::string>();
   }
 
-  return serde;
+  return kafka;
 }
 
 CsvProps asCsvProps(const YAML::Node& node) {
@@ -320,18 +326,22 @@ BucketInfo asBucketInfo(const YAML::Node& node) {
 // td = table definition
 std::shared_ptr<TableSpec> loadTable(std::string name, const YAML::Node& td) {
   auto ds = DataSourceUtils::from(td["data"].as<std::string>());
-
-  // TODO(cao): sorry but we have a hard rule here,
-  // every Kafka table will be named as "k.{topic_name}"
-  // we may want to turn this into an extra field in table rather than name.
-  if (ds == DataSource::KAFKA) {
-    // here we want topic name as table name
-    name = td["topic"].as<std::string>();
+  if (ds == DataSource::NEBULA) {
+    return nullptr;
   }
 
   // hour table level retention.max-hr as single way to ingest and evict data
   const auto retention = td["retention"];
 
+  // kafka requires topic to be set in "kafka section"
+  auto kafkaSerde = asKafka(td["kafka"]);
+  if (ds == DataSource::KAFKA && kafkaSerde.topic.size() == 0) {
+    LOG(WARNING) << "Kafka data requrires topic to be set";
+    return nullptr;
+  }
+
+  // (historical) convention removed that table name follows k.{topic}" for kafka
+  // in fact, we allow multiple tables connecting to the same streaming topic
   // max-hr could be fractional value to help us get granularity to seconds
   return std::make_shared<TableSpec>(
     name,
@@ -346,12 +356,35 @@ std::shared_ptr<TableSpec> loadTable(std::string name, const YAML::Node& td) {
     asCsvProps(td["csv"]),
     asJsonProps(td["json"]),
     asThriftProps(td["thrift"]),
-    asSerde(td["serde"]),
+    ,
     asColumnProps(td["columns"]),
     asTimeSpec(td["time"]),
     asAccessRules(td["access"]),
     asBucketInfo(td["bucket"]),
     asSettings(td["settings"]));
+}
+
+inline void processTableDefinitions(
+  const unordered_map<std::string, YAML::Node>& defs,
+  unordered_set<std::string>& names,
+  TableSpecSet& tables) noexcept {
+  // loading all dynamic table definitions from service calls
+  for (auto it = defs.begin(); it != defs.end(); ++it) {
+    const auto& name = it->first;
+    if (names.find(name) != names.end()) {
+      LOG(WARNING) << "Skip the same table name already defined: " << name;
+      continue;
+    }
+
+    // put the name in
+    names.emplace(name);
+
+    // max-hr could be fractional value to help us get granularity to seconds
+    auto tsp = loadTable(name, it->second);
+    if (tsp) {
+      tables.emplace(tsp);
+    }
+  }
 }
 
 void ClusterInfo::load(const std::string& file, CreateMetaDB createDb) {
@@ -399,39 +432,16 @@ void ClusterInfo::load(const std::string& file, CreateMetaDB createDb) {
   topLevels++;
 
   // avoid duplicate table name definition
-  nebula::common::unordered_set<std::string> nameSet;
   TableSpecSet tableSet;
+  unordered_set<std::string> nameSet;
+  unordered_map<std::string, YAML::Node> configTables;
   for (YAML::const_iterator it = tables.begin(); it != tables.end(); ++it) {
-    std::string name = it->first.as<std::string>();
-    if (nameSet.find(name) != nameSet.end()) {
-      LOG(WARNING) << "Skip the same table name already defined: " << name;
-      continue;
-    }
-
-    // put the name in
-    nameSet.emplace(name);
-
-    // table definition
-    const auto& td = it->second;
-
-    // max-hr could be fractional value to help us get granularity to seconds
-    tableSet.emplace(loadTable(name, td));
+    configTables.emplace(it->first.as<std::string>(), std::move(it->second));
   }
 
-  // loading all dynamic table definitions from service calls
-  for (auto it = runtimeTables_.begin(); it != runtimeTables_.end(); ++it) {
-    const auto& name = it->first;
-    if (nameSet.find(name) != nameSet.end()) {
-      LOG(WARNING) << "Skip the same table name already defined: " << name;
-      continue;
-    }
-
-    // put the name in
-    nameSet.emplace(name);
-
-    // load this table from run time
-    tableSet.emplace(loadTable(name, it->second));
-  }
+  // load tables from config first and then runtime tables
+  processTableDefinitions(configTables, nameSet, tableSet);
+  processTableDefinitions(runtimeTables_, nameSet, tableSet);
 
   // swap with new table set
   std::swap(tables_, tableSet);

--- a/src/meta/ClusterInfo.h
+++ b/src/meta/ClusterInfo.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <mutex>
+#include <yaml-cpp/yaml.h>
 
 #include "MetaDb.h"
 #include "NodeManager.h"
@@ -77,7 +78,17 @@ public:
   }
 
 public:
+  // load cluster info from config file
   void load(const std::string&, CreateMetaDB);
+
+  // table name and its yaml definition content
+  // should move to metadata server in future
+  std::string addTable(const std::string&, const std::string&);
+
+  // remove the table entry
+  inline size_t removeTable(const std::string& table) noexcept {
+    return runtimeTables_.erase(table);
+  }
 
   inline const std::vector<NNode> nodes() const {
     return nodeManager_->nodes();
@@ -122,6 +133,7 @@ private:
   std::string version_;
   ServerOptions server_;
   std::unique_ptr<MetaDb> db_;
+  nebula::common::unordered_map<std::string, YAML::Node> runtimeTables_;
 };
 } // namespace meta
 } // namespace nebula

--- a/src/meta/ClusterInfo.h
+++ b/src/meta/ClusterInfo.h
@@ -78,6 +78,11 @@ public:
   }
 
 public:
+  // internal state changes that may require a reload
+  inline bool shouldReload() const noexcept {
+    return stateChanged_;
+  }
+
   // load cluster info from config file
   void load(const std::string&, CreateMetaDB);
 
@@ -87,6 +92,7 @@ public:
 
   // remove the table entry
   inline size_t removeTable(const std::string& table) noexcept {
+    stateChanged_ = true;
     return runtimeTables_.erase(table);
   }
 
@@ -134,6 +140,7 @@ private:
   ServerOptions server_;
   std::unique_ptr<MetaDb> db_;
   nebula::common::unordered_map<std::string, YAML::Node> runtimeTables_;
+  bool stateChanged_;
 };
 } // namespace meta
 } // namespace nebula

--- a/src/meta/Table.h
+++ b/src/meta/Table.h
@@ -201,6 +201,10 @@ public:
   static constexpr auto WINDOW_COLUMN = "_window_";
 
 public:
+  inline bool empty() const noexcept {
+    return schema_ == nullptr;
+  }
+
   virtual Schema schema() const {
     N_ENSURE_NOT_NULL(schema_, fmt::format("invalid table not found = {0}", name_));
     return schema_;

--- a/src/meta/TableSpec.h
+++ b/src/meta/TableSpec.h
@@ -76,8 +76,11 @@ struct KafkaSerde {
   // size of each ingestion batch
   uint64_t size = 0;
 
+  // kafka topic
+  std::string topic;
+
   // make it msgpack serializable
-  MSGPACK_DEFINE(retention, size);
+  MSGPACK_DEFINE(retention, size, topic);
 };
 
 // key-value settings in both string types

--- a/src/meta/test/TestMeta.cpp
+++ b/src/meta/test/TestMeta.cpp
@@ -170,11 +170,12 @@ TEST(MetaTest, TestRuntimeTableDefinition) {
       max-hr: 24
     schema: "ROW<name:string, value:int>"
     data: kafka
-    topic: test2
     loader: Streaming
     source: broker:9092
     backup: s3://nebula/n116/
     format: json
+    kafka:
+      topic: test2
     columns:
       name:
         dict: true
@@ -200,11 +201,11 @@ TEST(MetaTest, TestRuntimeTableDefinition) {
   EXPECT_EQ(tables.size(), 4);
   for (auto itr = tables.cbegin(); itr != tables.cend(); ++itr) {
     LOG(INFO) << "TABLE: " << (*itr)->toString();
-    if ((*itr)->name == "test2") {
+    if ((*itr)->name == "k.test") {
       runtime = (*itr);
     }
   }
-  EXPECT_EQ(runtime->name, "test2");
+  EXPECT_EQ(runtime->name, "k.test");
   EXPECT_EQ(runtime->schema, "ROW<name:string, value:int>");
   EXPECT_EQ(runtime->loader, "Streaming");
   EXPECT_EQ(runtime->source, DataSource::KAFKA);

--- a/src/meta/test/TestMeta.cpp
+++ b/src/meta/test/TestMeta.cpp
@@ -151,6 +151,69 @@ TEST(MetaTest, TestClusterConfigLoad) {
   LOG(INFO) << "key1=" << test->settings.at("key1");
 }
 
+TEST(MetaTest, TestRuntimeTableDefinition) {
+  auto yamlFile = "configs/test.yml";
+  auto& clusterInfo = nebula::meta::ClusterInfo::singleton();
+
+  // invalid
+  auto error = clusterInfo.addTable("k.test", "");
+  EXPECT_TRUE(error.size() > 0);
+  LOG(ERROR) << "Error adding table: " << error;
+
+  // as long as there is one element, it will be treated as valid
+  error = clusterInfo.addTable("k.test", "data: xyz");
+  EXPECT_TRUE(error.size() == 0);
+
+  auto yamlTableDef = R"(
+    retention:
+      max-mb: 20000
+      max-hr: 24
+    schema: "ROW<name:string, value:int>"
+    data: kafka
+    topic: test2
+    loader: Streaming
+    source: broker:9092
+    backup: s3://nebula/n116/
+    format: json
+    columns:
+      name:
+        dict: true
+    time:
+      # kafka will inject a time column when specified provided
+      type: provided
+    settings:
+      batch: 100
+      kafka.timeout: 100
+    )";
+  error = clusterInfo.addTable("k.test", yamlTableDef);
+  EXPECT_EQ(error.size(), 0);
+
+  // add some runtime table into it and make sure it loads
+  clusterInfo.load(yamlFile, [](const nebula::meta::MetaConf&) {
+    return std::unique_ptr<nebula::meta::MetaDb>(new nebula::meta::VoidDb());
+  });
+
+  // make sure we have table that we just added in the runtime
+  // in addition to the ones loaded from static config
+  const auto& tables = clusterInfo.tables();
+  nebula::meta::TableSpecPtr runtime = nullptr;
+  EXPECT_EQ(tables.size(), 4);
+  for (auto itr = tables.cbegin(); itr != tables.cend(); ++itr) {
+    LOG(INFO) << "TABLE: " << (*itr)->toString();
+    if ((*itr)->name == "test2") {
+      runtime = (*itr);
+    }
+  }
+  EXPECT_EQ(runtime->name, "test2");
+  EXPECT_EQ(runtime->schema, "ROW<name:string, value:int>");
+  EXPECT_EQ(runtime->loader, "Streaming");
+  EXPECT_EQ(runtime->source, DataSource::KAFKA);
+  EXPECT_EQ(runtime->format, DataFormat::JSON);
+  EXPECT_EQ(runtime->settings.size(), 2);
+  EXPECT_EQ(runtime->settings.at("batch"), "100");
+  EXPECT_EQ(runtime->settings.at("kafka.timeout"), "100");
+}
+
 TEST(MetaTest, TestAccessRules) {
   auto schema = nebula::type::TypeSerializer::from(
     "ROW<_time_: bigint, id:int, event:string, email:string, fund:bigint>");

--- a/src/meta/test/TestTableSpec.cpp
+++ b/src/meta/test/TestTableSpec.cpp
@@ -31,7 +31,7 @@ TEST(MetaTest, TestTableSpecSerde) {
   CsvProps csvProps{ true, "sep" };
   JsonProps jsonProps{ "rows", { { "col1", "field1" } } };
   ThriftProps thriftProps{ "binary", { { "col1", 1 } } };
-  KafkaSerde kafkaSerde{ 1, 2 };
+  KafkaSerde kafkaSerde{ 1, 2, "topic" };
   ColumnProps columnProps{ { "c1", Column{} } };
   TimeSpec timeSpec{ TimeType::STATIC, 123, "ct", "xyz" };
   AccessSpec accessSpec{
@@ -70,6 +70,7 @@ TEST(MetaTest, TestTableSpecSerde) {
   EXPECT_EQ(spec2.thrift.columnsMap.at("col1"), 1);
   EXPECT_EQ(spec2.kafkaSerde.retention, 1);
   EXPECT_EQ(spec2.kafkaSerde.size, 2);
+  EXPECT_EQ(spec2.kafkaSerde.topic, "topic");
   EXPECT_EQ(spec2.columnProps.size(), 1);
   EXPECT_EQ(spec2.columnProps.at("c1").withBloomFilter, false);
   EXPECT_EQ(spec2.timeSpec.type, TimeType::STATIC);

--- a/src/service/base/LoadSpec.h
+++ b/src/service/base/LoadSpec.h
@@ -86,8 +86,6 @@ struct LoadSpec {
 
   // construct from the json object
   explicit LoadSpec(const rapidjson::Document& doc) {
-    N_ENSURE(doc.IsObject(), "json object expected in google sheet spec.");
-
     // root object
     auto obj = doc.GetObject();
 

--- a/src/service/server/NebulaServer.cpp
+++ b/src/service/server/NebulaServer.cpp
@@ -131,7 +131,12 @@ Status V1ServiceImpl::State(ServerContext*, const TableStateRequest* request, Ta
     return Status::CANCELLED;
   }
 
+  // the table is probably still in process if empty (schema not set yet)
   auto table = TableService::singleton()->query(tbl).table();
+  if (table->empty()) {
+    return Status::UNKNOWN;
+  }
+
   auto bm = BlockManager::init();
   // query the table's state
   auto metrics = bm->metrics(table->name());

--- a/src/service/server/NebulaServer.cpp
+++ b/src/service/server/NebulaServer.cpp
@@ -134,7 +134,7 @@ Status V1ServiceImpl::State(ServerContext*, const TableStateRequest* request, Ta
   // the table is probably still in process if empty (schema not set yet)
   auto table = TableService::singleton()->query(tbl).table();
   if (table->empty()) {
-    return Status::UNKNOWN;
+    return Status(StatusCode::UNKNOWN, "probably in process");
   }
 
   auto bm = BlockManager::init();

--- a/src/service/server/NebulaServer.cpp
+++ b/src/service/server/NebulaServer.cpp
@@ -544,14 +544,14 @@ void RunServer() {
         sign = fmt::format("{0}_{1}", size, nebula::common::Hasher::hash64(data.get(), size));
       }
 
-      if (sign != confSignature) {
+      auto& ci = nebula::meta::ClusterInfo::singleton();
+      if (sign != confSignature || ci.shouldReload()) {
         LOG(INFO) << "Loading nebula cluster config: " << conf;
 
         // update the sign
         confSignature = sign;
 
         // load the new conf
-        auto& ci = nebula::meta::ClusterInfo::singleton();
         ci.load(conf, nebula::service::base::createMetaDB);
 
         // TODO(cao) - how to support table schema/column props evolution?

--- a/src/storage/kafka/KafkaReader.cpp
+++ b/src/storage/kafka/KafkaReader.cpp
@@ -81,7 +81,7 @@ private:
 // build the subscription pipeline
 void KafkaReader::init() {
   // properties
-  const auto& topic = table_->name;
+  const auto& topic = table_->kafkaSerde.topic;
 
   // subscribe is designed for group balance, we use assign directly
   LOG(INFO) << "Consume " << table_->location << "/" << topic << ":" << segment_.id();

--- a/src/storage/kafka/KafkaTopic.h
+++ b/src/storage/kafka/KafkaTopic.h
@@ -61,12 +61,10 @@ struct KafkaSegment {
 class KafkaTopic {
 public:
   KafkaTopic(const std::string& brokers,
-             const std::string& topic,
              const nebula::meta::KafkaSerde& serde,
              const std::unordered_map<std::string, std::string>& settings,
              size_t timeoutMs = 5000)
     : brokers_{ brokers },
-      topic_{ topic },
       serde_{ serde },
       timeoutMs_{ timeoutMs },
       conf_{ nullptr },
@@ -85,7 +83,7 @@ public:
   }
 
   inline const std::string& topic() const {
-    return topic_;
+    return serde_.topic;
   }
 
   inline size_t timeoutMs() const {
@@ -97,7 +95,6 @@ private:
 
 private:
   std::string brokers_;
-  std::string topic_;
   nebula::meta::KafkaSerde serde_;
   size_t timeoutMs_;
 

--- a/src/storage/test/TestKafka.cpp
+++ b/src/storage/test/TestKafka.cpp
@@ -313,8 +313,9 @@ TEST(KafkaTest, DISABLED_TestLibKafkaConsumer) {
 
 TEST(KafkaTest, DISABLED_TestKafkaTopic) {
   nebula::meta::KafkaSerde serde;
+  serde.topic = TOPIC;
   nebula::meta::Settings settings;
-  nebula::storage::kafka::KafkaTopic topic(BROKERS, TOPIC, serde, settings);
+  nebula::storage::kafka::KafkaTopic topic(BROKERS, serde, settings);
 
   // 10 hours ago
   auto tenHr = nebula::common::Evidence::unix_timestamp() - 3600 * 10;
@@ -328,8 +329,9 @@ TEST(KafkaTest, DISABLED_TestKafkaTopic) {
 
 TEST(KafkaTest, DISABLED_TestKafkaReader) {
   nebula::meta::KafkaSerde serde;
+  serde.topic = TOPIC;
   nebula::meta::Settings settings;
-  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>(BROKERS, TOPIC, serde, settings);
+  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>(BROKERS, serde, settings);
 
   // 10 hours ago
   auto tenHr = nebula::common::Evidence::unix_timestamp() - 3600 * 10;
@@ -393,7 +395,7 @@ TEST(KafkaTest, TestKafkaSegmentSerde) {
 TEST(KafkaTest, DISABLED_TestSimpleNestedSchema) {
   nebula::meta::KafkaSerde serde;
   nebula::meta::Settings settings;
-  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>("<brokers>", "<topic>", serde, settings);
+  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>("<brokers>", serde, settings);
 
   // 10 hours ago
   auto tenHr = nebula::common::Evidence::unix_timestamp() - 3600 * 2;
@@ -461,7 +463,7 @@ TEST(KafkaTest, DISABLED_TestFetchConfig) {
   nebula::meta::Settings settings;
   serde.retention = 90000;
   serde.size = 60000;
-  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>("<broker>>", "<topic>", serde, settings);
+  auto topic = std::make_unique<nebula::storage::kafka::KafkaTopic>("<broker>>", serde, settings);
 
   // 1 hours ago
   auto oneHr = nebula::common::Evidence::unix_timestamp() - 3600 * 1;

--- a/test/redpanda/config.yaml
+++ b/test/redpanda/config.yaml
@@ -47,11 +47,12 @@ tables:
       max-hr: 48
     schema: "ROW<name:string, value:int>"
     data: kafka
-    topic: <TOPIC>
     loader: Streaming
     source: <BROKERS>
     backup: s3://nebula/n116/
     format: json
+    kafka:
+      topic: <TOPIC>
     columns:
       name:
         dict: true


### PR DESCRIPTION
In the future, these table definitions should go to metadata server (to be setup).