### PR TITLE
Fixes for macros in paths

### DIFF
--- a/src/common/Format.h
+++ b/src/common/Format.h
@@ -72,7 +72,7 @@ std::string format(const std::string_view fmtstr, const unordered_map<std::strin
             tokenStart = SIZE_T_LIMIT;
             continue;
           } else {
-            LOG(INFO) << "Token not found: " << token;
+            LOG(ERROR) << "Token not found: " << token;
             throw NException(fmt::format("token not found for fmt string: {0}.", token));
           }
         }
@@ -96,9 +96,7 @@ std::string format(const std::string_view fmtstr, const unordered_map<std::strin
   }
 
   // when the loop is done, tokenStart has to be 0 to indicate all tokens are replaced
-  if (!allowMissingMacro) {
   N_ENSURE_EQ(tokenStart, SIZE_T_LIMIT, "some open token not replaced - wrong format string.");
-  }
   N_ENSURE(bufferPos < MAX_TEXT, "format string is too long.");
 
   return std::string(buffer, bufferPos);

--- a/src/common/Format.h
+++ b/src/common/Format.h
@@ -39,7 +39,7 @@ namespace common {
 // auto text = nebula::common::format("I will go to {p} to do {x}", {{"p", "place"}, {"x", "something"}});
 // supporting max result size as 1024, expect exception if overflowing.
 template <size_t x = 0>
-std::string format(const std::string_view fmtstr, const unordered_map<std::string_view, std::string_view> macros) {
+std::string format(const std::string_view fmtstr, const unordered_map<std::string_view, std::string_view> macros, bool allowMissingMacro = false) {
   // support only MAX TEXT length for final resul, throw exception if not meet the expectation
   static constexpr auto MAX_TEXT = 1024;
   char buffer[MAX_TEXT];
@@ -62,10 +62,20 @@ std::string format(const std::string_view fmtstr, const unordered_map<std::strin
         // looking for the token and memcopy its value into buffer
         auto found = macros.find(token);
         if (found == macros.end()) {
-          LOG(INFO) << "Token not found: " << token;
-          throw NException(fmt::format("token not found for fmt string: {0}.", token));
+          if (allowMissingMacro) {
+            // copy macro with start/end back into buffer
+            buffer[bufferPos++] = TOKEN_START;
+            const auto size = token.size();
+            std::memcpy(buffer + bufferPos, token.data(), size);
+            bufferPos += size;
+            buffer[bufferPos++] = TOKEN_END;
+            tokenStart = SIZE_T_LIMIT;
+            continue;
+          } else {
+            LOG(INFO) << "Token not found: " << token;
+            throw NException(fmt::format("token not found for fmt string: {0}.", token));
+          }
         }
-
         // copy the value into buffer
         const auto& value = found->second;
         const auto size = value.size();
@@ -86,7 +96,9 @@ std::string format(const std::string_view fmtstr, const unordered_map<std::strin
   }
 
   // when the loop is done, tokenStart has to be 0 to indicate all tokens are replaced
+  if (!allowMissingMacro) {
   N_ENSURE_EQ(tokenStart, SIZE_T_LIMIT, "some open token not replaced - wrong format string.");
+  }
   N_ENSURE(bufferPos < MAX_TEXT, "format string is too long.");
 
   return std::string(buffer, bufferPos);

--- a/src/meta/Macro.h
+++ b/src/meta/Macro.h
@@ -212,7 +212,11 @@ public:
       return {input};
     }
     for (const auto& macroCombination : macroCombinations) {
-      results.push_back(nebula::common::format(input, macroCombination));
+      results.push_back(nebula::common::format(
+        input,
+        macroCombination,
+        true /* allowMissingMacro - allow missing macros for time macros */
+      ));
     }
     return results;
   }

--- a/src/meta/test/TestMacro.cpp
+++ b/src/meta/test/TestMacro.cpp
@@ -191,14 +191,14 @@ TEST(MacroTest, TestCustomMacros3) {
 }
 
 TEST(MacroTest, TestCustomMacros4) {
-  const auto path = "a/{b}";
+  const auto path = "a/{b}/{c}/{def}";
   const std::map<std::string, std::vector<std::string>> macroValues = {
     {"a", {"1", "2"}},
     {"b", {"1", "2"}}
   };
   const auto paths = Macro::enumeratePathsWithCustomMacros(path, macroValues);
 
-  const std::vector<std::string> expectedPaths = {"a/1", "a/2"};
+  const std::vector<std::string> expectedPaths = {"a/1/{c}/{def}", "a/2/{c}/{def}"};
 
   EXPECT_EQ(paths.size(), 2);
   for (const auto& expectedPath : expectedPaths) {


### PR DESCRIPTION
Support missing macros so some logic can fill in parts, and other logic can fill in the rest