### PR TITLE
test the file reported to cause OOM

### DIFF
--- a/src/configs/test.yml
+++ b/src/configs/test.yml
@@ -171,3 +171,15 @@ tables:
   #       macro: part
   #   time:
   #     type: current
+  oom.test:
+    retention:
+      max-mb: 10000
+      max-hr: 48
+    schema: "ROW<user_id:string, value: string,  event: string, metadata: string>"
+    data: local
+    loader: Swap
+    source: "file:///tmp/oom.snappy.parquet"
+    backup: s3://nebula/n100/
+    format: parquet
+    time:
+      type: current


### PR DESCRIPTION
Hey @ritvik-statsig,

Just try to repro with the file you send to me, unfortunately, I can not repro it. Pls, check the config I use and compare yours and see if there is any possible guess.

This is for investigating issue #163 

Steps:

1. copy the file you sent to `/tmp/oom.snappy.parquet`
2. add below config to use latest code to launch single-node nebula cluster
3. watch:

Data loaded correctly without issue as seen in Node log: 
```
I0302 22:41:05.525804 1830744064 TaskExecutor.cpp:128] processed task: macro.test@/tmp/oom.snappy.parquet@160445_I
I0302 22:41:05.527215 1830744064 IngestSpec.cpp:466] Ingesting from /tmp/nebula.lNqmqH
I0302 22:41:05.539216 1830744064 IngestSpec.cpp:547] Push a block: [raw: 817096, size: 1634020, allocation: 1634020, rows: 884, bess: 0]
```

So the sample file only cost 800KB of memory with 884.

Then I started web UI, the query is working alright - 

![Screen Shot 2022-03-02 at 10 53 19 PM](https://user-images.githubusercontent.com/26632293/156512409-9182ea39-258f-423b-ae8e-8bf490aeebd9.png)
 